### PR TITLE
make travis notify our slack room instead of emailing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,9 @@ deploy:
   on:
     tags: true
     repo: simplabs/qunit-dom
+
+notifications:
+  email: false
+  slack:
+    rooms:
+      secure: OOKD4ZksqzEBW/A3WRuOToODIxnDITqx+Esu7tdmmYPuQlMYgx4SUHv8j9OM9/ScFJiseeVGSkl45vJrHLLIITX9XSjO1RgiGZgw2heVujmGpF6CZNqvT6GsQuKIvMzmwF7IxuHdfV45Csr9Ou/Fg74TszR/4S2h4SOI4zhLg7A=


### PR DESCRIPTION
This is the same setup we use for our other projects as well. I think this is a better way of keeping up to date with the travis build status.