### PR TITLE
Use assert.dom(selector).exists() instead of assert.dom.exists(selector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Load `qunit-dom.js` *after* `qunit.js`:
 Usage
 ------------------------------------------------------------------------------
 
-Once installed the DOM element assertions are available at `assert.dom.*`:
+Once installed the DOM element assertions are available at `assert.dom(...).*`:
 
 ```js
 test('the title is friendly', function(assert) {
-  assert.dom.textContains('#title', 'Welcome');
+  assert.dom('#title').textContains('Welcome');
 });
 ```
 
@@ -53,48 +53,48 @@ test('the title is friendly', function(assert) {
 Assertions
 ------------------------------------------------------------------------------
 
-### `exists(selector, [options], [message])`
-### `missing(selector, [message])`
+### `assert.dom(selector).exists([options], [message])`
+### `assert.dom(selector).missing([message])`
 
 Assert an [HTMLElement][] (or multiple) matching the `selector` exists.
 
 ```js
-assert.dom.exists('#title');
-assert.dom.exists('.choice', { count: 4 });
-assert.dom.missing('.should-not-exist');
+assert.dom('#title').exists();
+assert.dom('.choice').exists({ count: 4 });
+assert.dom('.should-not-exist').missing();
 ```
 
 
-### `focused(selector|element, [message])`
-### `notFocused(selector|element, [message])`
+### `assert.dom(selector|element).focused([message])`
+### `assert.dom(selector|element).notFocused([message])`
 
 Assert that the [HTMLElement][] is or is not currently focused.
 
 ```js
-assert.dom.focused('input.email');
-assert.dom.notFocused(document.querySelector('input[type="password"]'));
+assert.dom('input.email').focused();
+assert.dom(document.querySelector('input[type="password"]')).notFocused();
 ```
 
 
-### `textContains(selector|element, text, [message])`
+### `assert.dom(selector|element).textContains(text, [message])`
 
 Assert that the text of the [HTMLElement][] contains the given `text`, using
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent).
 
 ```js
-assert.dom.textContains('#title', 'Welcome');
-assert.dom.textContains(document.querySelector('#title'), 'Welcome');
+assert.dom('#title').textContains('Welcome');
+assert.dom(document.querySelector('#title')).textContains('Welcome');
 ```
 
 
-### `textMatches(selector|element, regex, [message])`
+### `assert.dom(selector|element).textMatches(regex, [message])`
 
 Assert that the text of the [HTMLElement][] matches the given regular expression, using
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent).
 
 ```js
-assert.dom.textMatches('.foo', /[12]\d{3}/);
-assert.dom.textMatches(document.querySelector('.foo'), /[12]\d{3}/);
+assert.dom('.foo').textMatches(/[12]\d{3}/);
+assert.dom(document.querySelector('.foo')).textMatches(/[12]\d{3}/);
 ```
 
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,0 +1,45 @@
+import exists from './assertions/exists';
+import missing from './assertions/missing';
+import focused from './assertions/focused';
+import notFocused from './assertions/not-focused';
+import textContains from './assertions/text-contains';
+import textMatches from './assertions/text-matches';
+
+export default class DOMAssertions {
+  constructor(target, rootElement, testContext) {
+    this.target = target;
+    this.rootElement = rootElement;
+    this.testContext = testContext;
+  }
+
+  exists(options, message) {
+    exists.call(this, this.target, options, message);
+  }
+
+  missing(message) {
+    missing.call(this, this.target, message);
+  }
+
+  focused(message) {
+    focused.call(this, this.target, message);
+  }
+
+  notFocused(message) {
+    notFocused.call(this, this.target, message);
+  }
+
+  textContains(text, message) {
+    textContains.call(this, this.target, text, message);
+  }
+
+  textMatches(regex, message) {
+    textMatches.call(this, this.target, regex, message);
+  }
+
+  /**
+   * @private
+   */
+  pushResult(result) {
+    this.testContext.pushResult(result);
+  }
+}

--- a/lib/assertions.test.js
+++ b/lib/assertions.test.js
@@ -2,13 +2,13 @@
 
 const fs = require('fs');
 
-let bundleFile = fs.readFileSync(`${__dirname}/qunit-dom.js`, 'utf8');
+let assertionsClassFile = fs.readFileSync(`${__dirname}/assertions.js`, 'utf8');
 
 let assertions = fs.readdirSync(`${__dirname}/assertions`)
   .filter(it => it.indexOf('.test.js') === -1);
 
 assertions.forEach(filename => {
-  test(`${filename} is reexported`, () => {
-    expect(bundleFile).toContain(filename.replace(/\.js$/, ''));
+  test(`${filename} is imported`, () => {
+    expect(assertionsClassFile).toContain(filename.replace(/\.js$/, ''));
   });
 });

--- a/lib/qunit-dom.js
+++ b/lib/qunit-dom.js
@@ -1,22 +1,9 @@
 import * as QUnit from 'qunit';
 
-import exists from './assertions/exists';
-import missing from './assertions/missing';
-import focused from './assertions/focused';
-import notFocused from './assertions/not-focused';
-import textContains from './assertions/text-contains';
-import textMatches from './assertions/text-matches';
+import DOMAssertions from './assertions';
 
 QUnit.extend(QUnit.assert, {
-  dom: {
-    rootElement: document,
-    pushResult: QUnit.assert.pushResult,
-
-    exists,
-    missing,
-    focused,
-    notFocused,
-    textContains,
-    textMatches,
+  dom(target, rootElement) {
+    return new DOMAssertions(target, rootElement || document, this);
   }
 });

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -7,12 +7,12 @@ test('qunit-dom assertions are available', function(assert) {
   assert.expect(5);
 
   assert.ok(assert.dom, 'assert.dom is available');
-  assert.ok(assert.dom.textContains, 'assert.dom.textContains is available');
+  assert.ok(assert.dom('.foo').textContains, 'assert.dom(...).textContains is available');
 
   visit('/');
   andThen(() => {
-    assert.dom.exists('#title');
-    assert.dom.missing('#subtitle');
-    assert.dom.textContains('#title', 'Welcome');
+    assert.dom('#title').exists();
+    assert.dom('#subtitle').missing();
+    assert.dom('#title').textContains('Welcome');
   });
 });


### PR DESCRIPTION
Resolves #6 

This allows us to have a more friendly human-language API and the API is a little closer to https://github.com/cibernox/ember-native-dom-helpers where you can usually specify a custom `rootElement` as a second parameter that defaults to `document`.