### PR TITLE
tests/has-value: Ensure empty `value` does not break the assertion

### DIFF
--- a/lib/__tests__/has-value.js
+++ b/lib/__tests__/has-value.js
@@ -46,6 +46,25 @@ describe('assert.dom(...).hasValue()', () => {
         result: false,
       }]);
     });
+
+    test('fails for wrong content if field is empty', () => {
+      document.body.innerHTML = '<input>';
+
+      assert.dom('input').hasValue('Bart');
+      assert.dom(document.querySelector('input')).hasValue('Bart');
+
+      expect(assert.results).toEqual([{
+        actual: '',
+        expected: 'Bart',
+        message: 'Element input has value "Bart"',
+        result: false,
+      }, {
+        actual: '',
+        expected: 'Bart',
+        message: 'Element input has value "Bart"',
+        result: false,
+      }]);
+    });
   });
 
   describe('regex expected', () => {


### PR DESCRIPTION
Resolves #19 