### PR TITLE
Rename `hasTextContaining()` to `includesText()`

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,7 +174,7 @@ assert.dom('input[type="password"]').doesNotHaveClass('username-input');
 
 ### hasText
 
--   **See: [#hasTextContaining](#hastextcontaining)**
+-   **See: [#includesText](#includestext)**
 
 Assert that the text of the [HTMLElement][] or an [HTMLElement][]
 matching the `selector` matches the `expected` text, using the
@@ -202,7 +202,7 @@ assert.dom('#title').hasText('Welcome to QUnit');
 assert.dom('.foo').hasText(/[12]\d{3}/);
 ```
 
-### hasTextContaining
+### includesText
 
 -   **See: [#hasText](#hastext)**
 
@@ -211,7 +211,7 @@ matching the `selector` contains the given `text`, using the
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 attribute.
 
-**Aliases:** `includesText`
+**Aliases:** `containsText`, `hasTextContaining`
 
 **Parameters**
 
@@ -221,7 +221,7 @@ attribute.
 **Examples**
 
 ```javascript
-assert.dom('#title').hasTextContaining('Welcome');
+assert.dom('#title').includesText('Welcome');
 ```
 
 ### hasValue

--- a/lib/__tests__/includes-text.js
+++ b/lib/__tests__/includes-text.js
@@ -2,7 +2,7 @@
 
 import TestAssertions from "../helpers/test-assertions";
 
-describe('assert.dom(...).textContains()', () => {
+describe('assert.dom(...).includesText()', () => {
   let assert;
 
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('assert.dom(...).textContains()', () => {
   test('with custom message', () => {
     document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
 
-    assert.dom('h1').hasTextContaining('foo', 'bar');
+    assert.dom('h1').includesText('foo', 'bar');
 
     expect(assert.results).toEqual([{
       actual: 'foo',
@@ -31,7 +31,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('succeeds for correct content', () => {
-      assert.dom(element).hasTextContaining('foo');
+      assert.dom(element).includesText('foo');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -42,7 +42,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('succeeds for correct partial content', () => {
-      assert.dom(element).hasTextContaining('oo');
+      assert.dom(element).includesText('oo');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -53,7 +53,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('fails for wrong content', () => {
-      assert.dom(element).hasTextContaining('bar');
+      assert.dom(element).includesText('bar');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -64,7 +64,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).hasTextContaining('foo');
+      assert.dom(null).includesText('foo');
 
       expect(assert.results).toEqual([{
         message: 'Element <unknown> exists',
@@ -79,7 +79,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('succeeds for correct content', () => {
-      assert.dom('h1').hasTextContaining('foo');
+      assert.dom('h1').includesText('foo');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -90,7 +90,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('succeeds for correct partial content', () => {
-      assert.dom('h1').hasTextContaining('oo');
+      assert.dom('h1').includesText('oo');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -101,7 +101,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('fails for wrong content', () => {
-      assert.dom('h1').hasTextContaining('bar');
+      assert.dom('h1').includesText('bar');
 
       expect(assert.results).toEqual([{
         actual: 'foo',
@@ -112,7 +112,7 @@ describe('assert.dom(...).textContains()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom('h2').hasTextContaining('foo');
+      assert.dom('h2').includesText('foo');
 
       expect(assert.results).toEqual([{
         message: 'Element h2 exists',
@@ -122,10 +122,10 @@ describe('assert.dom(...).textContains()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
-    expect(() => assert.dom(5).hasTextContaining('foo')).toThrow('Unexpected Parameter: 5');
-    expect(() => assert.dom(true).hasTextContaining('foo')).toThrow('Unexpected Parameter: true');
-    expect(() => assert.dom(undefined).hasTextContaining('foo')).toThrow('Unexpected Parameter: undefined');
-    expect(() => assert.dom({}).hasTextContaining('foo')).toThrow('Unexpected Parameter: [object Object]');
-    expect(() => assert.dom(document).hasTextContaining('foo')).toThrow('Unexpected Parameter: [object HTMLDocument]');
+    expect(() => assert.dom(5).includesText('foo')).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).includesText('foo')).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).includesText('foo')).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).includesText('foo')).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).includesText('foo')).toThrow('Unexpected Parameter: [object HTMLDocument]');
   });
 });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -259,7 +259,7 @@ export default class DOMAssertions {
    * @example
    * assert.dom('.foo').hasText(/[12]\d{3}/);
    *
-   * @see {@link #hasTextContaining}
+   * @see {@link #includesText}
    */
   hasText(expected, message) {
     let element = this.findTargetElement();
@@ -294,17 +294,17 @@ export default class DOMAssertions {
    * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
    * attribute.
    *
-   * **Aliases:** `includesText`
+   * **Aliases:** `containsText`, `hasTextContaining`
    *
    * @param {string} text
    * @param {string?} message
    *
    * @example
-   * assert.dom('#title').hasTextContaining('Welcome');
+   * assert.dom('#title').includesText('Welcome');
    *
    * @see {@link #hasText}
    */
-  hasTextContaining(text, message) {
+  includesText(text, message) {
     let element = this.findTargetElement();
     if (!element) return;
 
@@ -319,8 +319,12 @@ export default class DOMAssertions {
     this.pushResult({ result, actual, expected, message });
   }
 
-  includesText(expected, message) {
-    this.hasTextContaining(expected, message);
+  containsText(expected, message) {
+    this.includesText(expected, message);
+  }
+
+  hasTextContaining(expected, message) {
+    this.includesText(expected, message);
   }
 
   /**

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -7,7 +7,7 @@ test('qunit-dom assertions are available', function(assert) {
   assert.expect(6);
 
   assert.ok(assert.dom, 'assert.dom is available');
-  assert.ok(assert.dom('.foo').hasTextContaining, 'assert.dom(...).textContains is available');
+  assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');
 
   assert.dom('#qunit').doesNotExist('rootElement is set to #ember-testing-container');
 


### PR DESCRIPTION
- Refactors `hasTextContaining()` to `includesText()`
- Adds `containsText()` as an alias for `includesText()`;
- Generates docs;