### PR TITLE
Ember: Convert `rootElement` to non-caching property

### DIFF
--- a/vendor/overwrite-qunit-dom-root-element.js
+++ b/vendor/overwrite-qunit-dom-root-element.js
@@ -1,1 +1,7 @@
-QUnit.assert.dom.rootElement = document.querySelector('#ember-testing');
+Object.defineProperty(QUnit.assert.dom, 'rootElement', {
+  get: function() {
+    return document.querySelector('#ember-testing');
+  },
+  enumerable: true,
+  configurable: true,
+});


### PR DESCRIPTION
This makes the library compatible with the recent changes in `ember-test-helpers` where the `#ember-testing` element is recreated for each test instead of reusing the existing one.

/cc @rwjblue