### PR TITLE
Add `doesNotIncludeText()` assertion

### DIFF
--- a/API.md
+++ b/API.md
@@ -231,6 +231,8 @@ matching the `selector` does not contain the given `text`, using the
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 attribute.
 
+**Aliases:** `doesNotContainText`, `doesNotHaveTextContaining`
+
 **Parameters**
 
 -   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 

--- a/API.md
+++ b/API.md
@@ -224,6 +224,24 @@ attribute.
 assert.dom('#title').includesText('Welcome');
 ```
 
+### doesNotIncludeText
+
+Assert that the text of the [HTMLElement][] or an [HTMLElement][]
+matching the `selector` does not contain the given `text`, using the
+[`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
+attribute.
+
+**Parameters**
+
+-   `text` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** 
+-   `message` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+**Examples**
+
+```javascript
+assert.dom('#title').doesNotIncludeText('Welcome');
+```
+
 ### hasValue
 
 -   **See: [#hasAnyValue](#hasanyvalue)**

--- a/API.md
+++ b/API.md
@@ -227,7 +227,7 @@ assert.dom('#title').includesText('Welcome');
 ### doesNotIncludeText
 
 Assert that the text of the [HTMLElement][] or an [HTMLElement][]
-matching the `selector` does not contain the given `text`, using the
+matching the `selector` does not include the given `text`, using the
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 attribute.
 

--- a/lib/__tests__/does-not-include-text.js
+++ b/lib/__tests__/does-not-include-text.js
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+
+import TestAssertions from "../helpers/test-assertions";
+
+describe('assert.dom(...).doesNotIncludeText()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  test('with custom message', () => {
+    document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+    assert.dom('h1').doesNotIncludeText('baz', 'bing');
+
+    expect(assert.results).toEqual([{
+      actual: 'foo',
+      expected: 'baz',
+      message: 'bing',
+      result: true,
+    }]);
+  });
+
+  describe('with HTMLElement', () => {
+    let element;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+      element = document.querySelector('h1');
+    });
+
+    test('succeeds for correct content', () => {
+      assert.dom(element).doesNotIncludeText('baz');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo',
+        expected: 'baz',
+        message: 'Element h1.baz does not have text containing "baz"',
+        result: true,
+      }]);
+    });
+
+    test('fails for wrong content', () => {
+      assert.dom(element).doesNotIncludeText('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo',
+        expected: 'foo',
+        message: 'Element h1.baz does not have text containing "foo"',
+        result: false,
+      }]);
+    });
+
+    test('fails for missing element', () => {
+      assert.dom(null).doesNotIncludeText('foo');
+
+      expect(assert.results).toEqual([{
+        message: 'Element <unknown> exists',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('with selector', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+    });
+
+    test('succeeds for correct content', () => {
+      assert.dom('h1').doesNotIncludeText('bar');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo',
+        expected: 'bar',
+        message: 'Element h1 does not have text containing "bar"',
+        result: true,
+      }]);
+    });
+
+    test('fails for wrong content', () => {
+      assert.dom('h1').doesNotIncludeText('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo',
+        expected: 'foo',
+        message: 'Element h1 does not have text containing "foo"',
+        result: false,
+      }]);
+    });
+
+    test('fails for missing element', () => {
+      assert.dom('h2').doesNotIncludeText('foo');
+
+      expect(assert.results).toEqual([{
+        message: 'Element h2 exists',
+        result: false,
+      }]);
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/__tests__/does-not-include-text.js
+++ b/lib/__tests__/does-not-include-text.js
@@ -15,8 +15,8 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
     assert.dom('h1').doesNotIncludeText('baz', 'bing');
 
     expect(assert.results).toEqual([{
-      actual: 'foo',
-      expected: 'baz',
+      actual: "Element h1 does not include text \"baz\"",
+      expected: "Element h1 does not include text \"baz\"",
       message: 'bing',
       result: true,
     }]);
@@ -34,9 +34,9 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom(element).doesNotIncludeText('baz');
 
       expect(assert.results).toEqual([{
-        actual: 'foo',
-        expected: 'baz',
-        message: 'Element h1.baz does not include text "baz"',
+        actual: "Element h1.baz does not include text \"baz\"",
+        expected: "Element h1.baz does not include text \"baz\"",
+        message: 'Expected element h1.baz to not include text "baz"',
         result: true,
       }]);
     });
@@ -45,9 +45,9 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom(element).doesNotIncludeText('foo');
 
       expect(assert.results).toEqual([{
-        actual: 'foo',
-        expected: 'foo',
-        message: 'Element h1.baz does not include text "foo"',
+        actual: 'Element h1.baz includes text "foo"',
+        expected: 'Element h1.baz does not include text "foo"',
+        message: 'Expected element h1.baz to not include text "foo"',
         result: false,
       }]);
     });
@@ -71,9 +71,9 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom('h1').doesNotIncludeText('bar');
 
       expect(assert.results).toEqual([{
-        actual: 'foo',
-        expected: 'bar',
-        message: 'Element h1 does not include text "bar"',
+        actual: 'Element h1 does not include text "bar"',
+        expected: 'Element h1 does not include text "bar"',
+        message: 'Expected element h1 to not include text "bar"',
         result: true,
       }]);
     });
@@ -82,9 +82,9 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom('h1').doesNotIncludeText('foo');
 
       expect(assert.results).toEqual([{
-        actual: 'foo',
-        expected: 'foo',
-        message: 'Element h1 does not include text "foo"',
+        actual: 'Element h1 includes text "foo"',
+        expected: 'Element h1 does not include text "foo"',
+        message: 'Expected element h1 to not include text "foo"',
         result: false,
       }]);
     });

--- a/lib/__tests__/does-not-include-text.js
+++ b/lib/__tests__/does-not-include-text.js
@@ -36,7 +36,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: "Element h1.baz does not include text \"baz\"",
         expected: "Element h1.baz does not include text \"baz\"",
-        message: 'Expected element h1.baz to not include text "baz"',
+        message: "Element h1.baz does not include text \"baz\"",
         result: true,
       }]);
     });
@@ -47,7 +47,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'Element h1.baz includes text "foo"',
         expected: 'Element h1.baz does not include text "foo"',
-        message: 'Expected element h1.baz to not include text "foo"',
+        message: 'Element h1.baz does not include text "foo"',
         result: false,
       }]);
     });
@@ -73,7 +73,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'Element h1 does not include text "bar"',
         expected: 'Element h1 does not include text "bar"',
-        message: 'Expected element h1 to not include text "bar"',
+        message: 'Element h1 does not include text "bar"',
         result: true,
       }]);
     });
@@ -84,7 +84,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'Element h1 includes text "foo"',
         expected: 'Element h1 does not include text "foo"',
-        message: 'Expected element h1 to not include text "foo"',
+        message: 'Element h1 does not include text "foo"',
         result: false,
       }]);
     });

--- a/lib/__tests__/does-not-include-text.js
+++ b/lib/__tests__/does-not-include-text.js
@@ -36,7 +36,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo',
         expected: 'baz',
-        message: 'Element h1.baz does not have text containing "baz"',
+        message: 'Element h1.baz does not include text "baz"',
         result: true,
       }]);
     });
@@ -47,7 +47,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo',
         expected: 'foo',
-        message: 'Element h1.baz does not have text containing "foo"',
+        message: 'Element h1.baz does not include text "foo"',
         result: false,
       }]);
     });
@@ -73,7 +73,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo',
         expected: 'bar',
-        message: 'Element h1 does not have text containing "bar"',
+        message: 'Element h1 does not include text "bar"',
         result: true,
       }]);
     });
@@ -84,7 +84,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo',
         expected: 'foo',
-        message: 'Element h1 does not have text containing "foo"',
+        message: 'Element h1 does not include text "foo"',
         result: false,
       }]);
     });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -333,6 +333,8 @@ export default class DOMAssertions {
    * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
    * attribute.
    *
+   * **Aliases:** `doesNotContainText`, `doesNotHaveTextContaining`
+   *
    * @param {string} text
    * @param {string?} message
    *
@@ -352,6 +354,14 @@ export default class DOMAssertions {
     }
 
     this.pushResult({ result, actual, expected, message });
+  }
+
+  doesNotContainText(expected, message) {
+    this.doesNotIncludeText(expected, message);
+  }
+
+  doesNotHaveTextContaining(expected, message) {
+    this.doesNotIncludeText(expected, message);
   }
 
   /**

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -328,6 +328,33 @@ export default class DOMAssertions {
   }
 
   /**
+   * Assert that the text of the [HTMLElement][] or an [HTMLElement][]
+   * matching the `selector` does not contain the given `text`, using the
+   * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
+   * attribute.
+   *
+   * @param {string} text
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('#title').doesNotIncludeText('Welcome');
+   */
+  doesNotIncludeText(text, message) {
+    let element = this.findTargetElement();
+    if (!element) return;
+
+    let result = element.textContent.indexOf(text) === -1;
+    let actual = element.textContent;
+    let expected = text;
+
+    if (!message) {
+      message = `Element ${this.targetDescription} does not have text containing "${text}"`;
+    }
+
+    this.pushResult({ result, actual, expected, message });
+  }
+
+  /**
    * Assert that the `value` property of an [HTMLInputElement][] matches
    * the `expected` text or regular expression.
    *

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -349,7 +349,7 @@ export default class DOMAssertions {
     let expected = `Element ${this.targetDescription} does not include text "${text}"`;
     let actual = expected;
 
-    if(!result) {
+    if (!result) {
       actual = `Element ${this.targetDescription} includes text "${text}"`;
     }
 

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -354,7 +354,7 @@ export default class DOMAssertions {
     }
 
     if (!message) {
-      message = `Expected element ${this.targetDescription} to not include text "${text}"`;
+      message = expected;
     }
 
     this.pushResult({ result, actual, expected, message });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -346,14 +346,18 @@ export default class DOMAssertions {
     if (!element) return;
 
     let result = element.textContent.indexOf(text) === -1;
-    let actual = element.textContent;
-    let unexpected = text;
+    let expected = `Element ${this.targetDescription} does not include text "${text}"`;
+    let actual = expected;
 
-    if (!message) {
-      message = `Element ${this.targetDescription} does not include text "${text}"`;
+    if(!result) {
+      actual = `Element ${this.targetDescription} includes text "${text}"`;
     }
 
-    this.pushResult({ result, actual, expected: unexpected, message });
+    if (!message) {
+      message = `Expected element ${this.targetDescription} to not include text "${text}"`;
+    }
+
+    this.pushResult({ result, actual, expected, message });
   }
 
   doesNotContainText(unexpected, message) {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -329,7 +329,7 @@ export default class DOMAssertions {
 
   /**
    * Assert that the text of the [HTMLElement][] or an [HTMLElement][]
-   * matching the `selector` does not contain the given `text`, using the
+   * matching the `selector` does not include the given `text`, using the
    * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
    * attribute.
    *
@@ -347,21 +347,21 @@ export default class DOMAssertions {
 
     let result = element.textContent.indexOf(text) === -1;
     let actual = element.textContent;
-    let expected = text;
+    let unexpected = text;
 
     if (!message) {
-      message = `Element ${this.targetDescription} does not have text containing "${text}"`;
+      message = `Element ${this.targetDescription} does not include text "${text}"`;
     }
 
-    this.pushResult({ result, actual, expected, message });
+    this.pushResult({ result, actual, expected: unexpected, message });
   }
 
-  doesNotContainText(expected, message) {
-    this.doesNotIncludeText(expected, message);
+  doesNotContainText(unexpected, message) {
+    this.doesNotIncludeText(unexpected, message);
   }
 
-  doesNotHaveTextContaining(expected, message) {
-    this.doesNotIncludeText(expected, message);
+  doesNotHaveTextContaining(unexpected, message) {
+    this.doesNotIncludeText(unexpected, message);
   }
 
   /**


### PR DESCRIPTION
There appears to be a pattern of having a positive and a negative assertion for any given property/attribute. E.g. `isFocused` and `isNotFocused`, `hasAttribute` and `doesNotHaveAttribute`, and `hasClass` and `doesNotHaveClass`. 

With that being said, it appears that there doesn't appear to be a corresponding inverse for the `includesText` assertion. Until now!