### PR TITLE
Collapse non-breaking whitespace.

### DIFF
--- a/lib/helpers/collapse-whitespace.js
+++ b/lib/helpers/collapse-whitespace.js
@@ -1,7 +1,7 @@
 export default function collapseWhitespace(string) {
   return string
     .replace(/[\t\r\n]/g, ' ')
-    .replace(/ +/g, ' ')
+    .replace(/\s+/g, ' ')
     .replace(/^ /, '')
     .replace(/ $/, '');
 }

--- a/lib/helpers/collapse-whitespace.test.js
+++ b/lib/helpers/collapse-whitespace.test.js
@@ -2,6 +2,9 @@
 
 import collapseWhitespace from './collapse-whitespace';
 
+let testElement = document.createElement('div');
+testElement.innerHTML = ' &nbsp; a &nbsp; b &nbsp; ';
+
 const TESTS = [
   ['', ''],
   ['abc', 'abc'],
@@ -10,6 +13,7 @@ const TESTS = [
   [' a b c ', 'a b c'],
   [' a\r\n b c ', 'a b c'],
   ['\n    foo equals\n    bar\n  ', 'foo equals bar'],
+  [testElement.textContent, 'a b'],
 ];
 
 TESTS.forEach(it => {


### PR DESCRIPTION
`&nbsp;` entity wasn't being collapsed, so HTML like `<div>10&nbsp;users online</div>` couldn't be matched with `assert.dom('div').hasText(/10 users/)`

This PR replaces `/ +/` regex with `/\s+/`.
Test included.