### PR TITLE
Add isVisible() and isNotVisible() assertions

### DIFF
--- a/lib/__tests__/is-not-visible.js
+++ b/lib/__tests__/is-not-visible.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import TestAssertions from '../helpers/test-assertions';
+
+describe('assert.dom(...).isNotVisible()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('selector only', () => {
+    test('fails if element is missing', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h2').isNotVisible();
+
+      expect(assert.results).toEqual([{
+        message: 'Element h2 exists',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('custom messages', () => {
+    test('shows custom messages', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h1').isNotVisible('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'Element h1 is not visible',
+        expected: 'Element h1 is not visible',
+        message: 'foo',
+        result: true,
+      }]);
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).isNotVisible()).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).isNotVisible()).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).isNotVisible()).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).isNotVisible()).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).isNotVisible()).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/__tests__/is-visible.js
+++ b/lib/__tests__/is-visible.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import TestAssertions from '../helpers/test-assertions';
+
+describe('assert.dom(...).isVisible()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('selector only', () => {
+    test('fails if element is missing', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h2').isVisible();
+
+      expect(assert.results).toEqual([{
+        message: 'Element h2 exists',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('custom messages', () => {
+    test('shows custom messages', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h1').isVisible('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'Element h1 is not visible',
+        expected: 'Element h1 is visible',
+        message: 'foo',
+        result: false,
+      }]);
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).isVisible()).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).isVisible()).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).isVisible()).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).isVisible()).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).isVisible()).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -2,6 +2,7 @@ import exists from './assertions/exists';
 import focused from './assertions/focused';
 import notFocused from './assertions/not-focused';
 
+import visible from './helpers/visible';
 import elementToString from './helpers/element-to-string';
 import collapseWhitespace from './helpers/collapse-whitespace';
 
@@ -460,6 +461,58 @@ export default class DOMAssertions {
 
   lacksValue(message) {
     this.hasNoValue(message);
+  }
+
+  /**
+   * Assert an [HTMLElement][] matching the `selector` is visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isVisible();
+   *
+   */
+  isVisible(message) {
+    let element = this.findTargetElement();
+    if (!element) return;
+
+    let result = visible(element);
+    let actual = result
+      ? `Element ${this.target} is visible`
+      : `Element ${this.target} is not visible`;
+    let expected = `Element ${this.target} is visible`;
+
+    if (!message) {
+      message = expected;
+    }
+
+    this.pushResult({ result, actual, expected, message });
+  }
+
+  /**
+   * Assert an [HTMLElement][] matching the `selector` is not visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isNotVisible();
+   *
+   */
+  isNotVisible(message) {
+    let element = this.findTargetElement();
+    if (!element) return;
+
+    let result = !visible(element);
+    let actual = result
+      ? `Element ${this.target} is not visible`
+      : `Element ${this.target} is visible`;
+    let expected = `Element ${this.target} is not visible`;
+
+    if (!message) {
+      message = expected;
+    }
+
+    this.pushResult({ result, actual, expected, message });
   }
 
   /**

--- a/lib/helpers/visible.js
+++ b/lib/helpers/visible.js
@@ -1,0 +1,6 @@
+// Visible logic based on jQuery's
+// https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
+
+export default function visible(el) {
+  return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+}

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -4,7 +4,7 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | qunit-dom');
 
 test('qunit-dom assertions are available', function(assert) {
-  assert.expect(6);
+  assert.expect(11);
 
   assert.ok(assert.dom, 'assert.dom is available');
   assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');
@@ -16,5 +16,12 @@ test('qunit-dom assertions are available', function(assert) {
     assert.dom('#title').exists();
     assert.dom('#subtitle').doesNotExist();
     assert.dom('#title').hasText('Welcome to Ember');
+
+    // isVisible/isNotVisible tests
+    assert.dom('#title').isVisible();
+    assert.dom('#display-block').isVisible();
+    assert.dom('#display-none').isNotVisible();
+    assert.dom('#display-descendant').isNotVisible();
+    assert.dom('#hidden-input').isNotVisible();
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,11 @@
 <h2 id="title">
   Welcome to <b>Ember</b>
 </h2>
+<p id="display-none" style="display: none;">You can't see me.</p>
+<div style="display: none;">
+  <p id="display-descendant" style="display: block;">You can't see me.</p>
+</div>
+<p id="display-block" style="display: block;">You can see me.</p>
+<input id="hidden-input" type="hidden">
 
 {{outlet}}


### PR DESCRIPTION
Fixes https://github.com/simplabs/qunit-dom/issues/52

Adds `isVisible` and `isNotVisible` assertion helpers.

Visibility is modelled off of jQuery's `:visible` logic in jQuery 3.0 https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13

From https://api.jquery.com/hidden-selector/, an element is considered "hidden" if it follows any of the following criteria

> They have a CSS display value of none.
They are form elements with type="hidden".
Their width and height are explicitly set to 0.
An ancestor element is hidden, so the element is not shown on the page.
Elements with visibility: hidden or opacity: 0 are considered to be visible, since they still consume space in the layout.
elements will be considered :hidden if they don't have any layout boxes. For example, br elements and inline elements with no content will not be selected by the :hidden selector.

As mentioned in the issue you may decide not to merge this. If you do, I can then update the README information.