### PR TITLE
Add helpful error for invalid attributes to hasText

### DIFF
--- a/lib/__tests__/has-text.js
+++ b/lib/__tests__/has-text.js
@@ -106,4 +106,21 @@ describe('assert.dom(...).hasText()', () => {
     expect(() => assert.dom({}).hasText('foo')).toThrow('Unexpected Parameter: [object Object]');
     expect(() => assert.dom(document).hasText('foo')).toThrow('Unexpected Parameter: [object HTMLDocument]');
   });
+
+  describe('invalid arguments to `hasText`', () => {
+    let element;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<h2 id="title">\n\tWelcome to <b>QUnit</b>\n</h2>\n';
+      element = document.querySelector('#title');
+    });
+
+    test('passing a number to `hasText` will throw an error', () => {
+      expect(() => assert.dom(element).hasText(1234)).toThrow('You must pass a string or Regular Expression to "hasText". You passed 1234');
+    });
+
+    test('passing an object to `hasText` will throw an error', () => {
+      expect(() => assert.dom(element).hasText({})).toThrow('You must pass a string or Regular Expression to "hasText". You passed [object Object]');
+    });
+  });
 });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -275,7 +275,7 @@ export default class DOMAssertions {
 
       this.pushResult({ result, actual, expected, message });
 
-    } else {
+    } else if (typeof expected === 'string') {
       expected = collapseWhitespace(expected);
       let actual = collapseWhitespace(element.textContent);
       let result = actual === expected;
@@ -285,6 +285,8 @@ export default class DOMAssertions {
       }
 
       this.pushResult({ result, actual, expected, message });
+    } else {
+      throw new TypeError(`You must pass a string or Regular Expression to "hasText". You passed ${expected}.`);
     }
   }
 


### PR DESCRIPTION
This adds a helpful error message when passing an invalid attribute to `hasText`. 

Resolves https://github.com/simplabs/qunit-dom/issues/47