### PR TITLE
Allow calling `assert.dom()` with no argument defaulting to `rootElement`

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,7 +12,7 @@ Once installed the DOM element assertions are available at `assert.dom(...).*`:
 
 **Parameters**
 
--   `target` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element))** A CSS selector that can be used to find elements using [`querySelector()`](https://developer.mozilla.org/de/docs/Web/API/Document/querySelector), or an [HTMLElement][] (Not all assertions support both target types.)
+-   `target` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element))** A CSS selector that can be used to find elements using [`querySelector()`](https://developer.mozilla.org/de/docs/Web/API/Document/querySelector), or an [HTMLElement][] (Not all assertions support both target types.) (optional, default `rootElement` or `document`)
 -   `rootElement` **[HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)?** The root element of the DOM in which to search for the `target` (optional, default `document`)
 
 **Examples**

--- a/lib/qunit-dom.js
+++ b/lib/qunit-dom.js
@@ -4,6 +4,7 @@ import DOMAssertions from './assertions';
 
 QUnit.extend(QUnit.assert, {
   dom(target, rootElement) {
-    return new DOMAssertions(target, rootElement || this.dom.rootElement || document, this);
+    rootElement = rootElement || this.dom.rootElement || document;
+    return new DOMAssertions(target || rootElement, rootElement, this);
   }
 });

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -4,12 +4,14 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | qunit-dom');
 
 test('qunit-dom assertions are available', function(assert) {
-  assert.expect(6);
+  assert.expect(7);
 
   assert.ok(assert.dom, 'assert.dom is available');
   assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');
 
   assert.dom('#qunit').doesNotExist('rootElement is set to #ember-testing-container');
+
+  assert.dom().hasAttribute('id', 'ember-testing');
 
   visit('/');
   andThen(() => {


### PR DESCRIPTION
Resolves #57

cc @spencer516