### PR TITLE
Add isDisabled() assertion

### DIFF
--- a/lib/__tests__/is-disabled.js
+++ b/lib/__tests__/is-disabled.js
@@ -1,0 +1,72 @@
+/* eslint-env jest */
+
+import TestAssertions from "../helpers/test-assertions";
+
+describe('assert.dom(...).isDisabled()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('input tags', () => {
+    test('succeeds when input is disabled', () => {
+      document.body.innerHTML = '<input disabled>';
+
+      assert.dom('input').isDisabled();
+      assert.dom(document.querySelector('input')).isDisabled();
+
+      expect(assert.results).toEqual([{
+        actual: 'Element input is disabled',
+        expected: 'Element input is disabled',
+        message: 'Element input is disabled',
+        result: true,
+      }, {
+        actual: 'Element input[disabled] is disabled',
+        expected: 'Element input[disabled] is disabled',
+        message: 'Element input[disabled] is disabled',
+        result: true,
+      }]);
+    });
+
+    test('fails when input is not disabled', () => {
+      document.body.innerHTML = '<input>';
+
+      assert.dom('input').isDisabled();
+      assert.dom(document.querySelector('input')).isDisabled();
+
+      expect(assert.results).toEqual([{
+        actual: 'Element input is not disabled',
+        expected: 'Element input is disabled',
+        message: 'Element input is disabled',
+        result: false,
+      }, {
+        actual: 'Element input is not disabled',
+        expected: 'Element input is disabled',
+        message: 'Element input is disabled',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('non-disablable elements', () => {
+    test('fails when element does not support disabled', () => {
+      document.body.innerHTML = '<div id="dis" disabled><div>';
+
+      assert.dom('div#dis').isDisabled();
+      assert.dom(document.querySelector('div#dis')).isDisabled();
+
+      expect(assert.results).toEqual([{
+        actual: 'Element div#dis does not support disabled',
+        expected: 'Element div#dis is disabled',
+        message: 'Element div#dis is disabled',
+        result: false,
+      }, {
+        actual: 'Element div#dis[disabled] does not support disabled',
+        expected: 'Element div#dis[disabled] is disabled',
+        message: 'Element div#dis[disabled] is disabled',
+        result: false,
+      }]);
+    });
+  });
+});

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -135,6 +135,27 @@ export default class DOMAssertions {
     }
   }
 
+  isDisabled(message) {
+    let element = this.findTargetElement();
+
+    let expected = `Element ${this.targetDescription} is disabled`;
+    let actual = `Element ${this.targetDescription} is disabled`;
+    let result = element.disabled;
+
+    if (result === false) {
+      actual = `Element ${this.targetDescription} is not disabled`;
+    } else if(result === undefined) {
+      actual = `Element ${this.targetDescription} does not support disabled`;
+      result = false;
+    }
+
+    if (!message) {
+      message = expected;
+    }
+
+    this.pushResult({ result, actual, expected, message });
+  }
+
   /**
    * Assert that the [HTMLElement][] has no attribute with the provided `name`.
    *


### PR DESCRIPTION
Worked with @habdelra at contribs workshop.


Do we care about other edgecases:

* Setting disabled to a string value (ex. `disabled="disabled"`)
* Setting disabled to the value false in HTML `disabled="false" (this is actually will give `element.disabled === true` when accessed via JS, do we want to warn users of this edcase or leave to linting)

Resolves #38