### PR TITLE
Add isVisible and isNotVisible assertion helpers

### DIFF
--- a/API.md
+++ b/API.md
@@ -163,6 +163,48 @@ Assert that the [HTMLElement][] or an [HTMLElement][] matching the
 assert.dom('input[type="text"]').isNotRequired();
 ```
 
+### isVisible
+
+Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+`selector` is visible. Visibility is determined with the hueristic
+used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
+specifically:
+
+-   is the element's offsetWidth non-zero
+-   is the element's offsetHeight non-zero
+-   is the length of an element's DOMRect objects found via getClientRects() non-zero
+
+**Parameters**
+
+-   `message` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+**Examples**
+
+```javascript
+assert.dom('.foo').isVisible();
+```
+
+### isNotVisible
+
+Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+`selector` is not visible. Visibility is determined with the hueristic
+used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
+specifically:
+
+-   is the element's offsetWidth non-zero
+-   is the element's offsetHeight non-zero
+-   is the length of an element's DOMRect objects found via getClientRects() non-zero
+
+**Parameters**
+
+-   `message` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+**Examples**
+
+```javascript
+assert.dom('.foo').isNotVisible();
+```
+
 ### hasAttribute
 
 -   **See: [#doesNotHaveAttribute](#doesnothaveattribute)**

--- a/lib/__tests__/is-not-visible.js
+++ b/lib/__tests__/is-not-visible.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import TestAssertions from '../helpers/test-assertions';
+
+describe('assert.dom(...).isNotVisible()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('selector only', () => {
+    test('fails if element is missing', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h2').isNotVisible();
+
+      expect(assert.results).toEqual([{
+        message: 'Element h2 exists',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('custom messages', () => {
+    test('shows custom messages', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h1').isNotVisible('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'Element h1 is not visible',
+        expected: 'Element h1 is not visible',
+        message: 'foo',
+        result: true,
+      }]);
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).isNotVisible()).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).isNotVisible()).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).isNotVisible()).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).isNotVisible()).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).isNotVisible()).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/__tests__/is-visible.js
+++ b/lib/__tests__/is-visible.js
@@ -1,0 +1,47 @@
+/* eslint-env jest */
+
+import TestAssertions from '../helpers/test-assertions';
+
+describe('assert.dom(...).isVisible()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('selector only', () => {
+    test('fails if element is missing', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h2').isVisible();
+
+      expect(assert.results).toEqual([{
+        message: 'Element h2 exists',
+        result: false,
+      }]);
+    });
+  });
+
+  describe('custom messages', () => {
+    test('shows custom messages', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom('h1').isVisible('foo');
+
+      expect(assert.results).toEqual([{
+        actual: 'Element h1 is not visible',
+        expected: 'Element h1 is visible',
+        message: 'foo',
+        result: false,
+      }]);
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).isVisible()).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).isVisible()).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).isVisible()).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).isVisible()).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).isVisible()).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -140,7 +140,13 @@ export default class DOMAssertions {
 
   /**
    * Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-   * `selector` is visible.
+   * `selector` is visible. Visibility is determined with the hueristic
+   * used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
+   * specifically:
+   *
+   * - is the element's offsetWidth non-zero
+   * - is the element's offsetHeight non-zero
+   * - is the length of an element's DOMRect objects found via getClientRects() non-zero
    *
    * @param {string?} message
    *
@@ -154,7 +160,13 @@ export default class DOMAssertions {
 
   /**
    *  Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-   * `selector` is not visible.
+   * `selector` is not visible. Visibility is determined with the hueristic
+   * used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
+   * specifically:
+   *
+   * - is the element's offsetWidth non-zero
+   * - is the element's offsetHeight non-zero
+   * - is the length of an element's DOMRect objects found via getClientRects() non-zero
    *
    * @param {string?} message
    *

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -6,6 +6,7 @@ import isNotChecked from './assertions/is-not-checked';
 import isRequired from './assertions/is-required';
 import isNotRequired from './assertions/is-not-required';
 
+import visible from './helpers/visible';
 import elementToString from './helpers/element-to-string';
 import collapseWhitespace from './helpers/collapse-whitespace';
 
@@ -572,6 +573,58 @@ export default class DOMAssertions {
 
   lacksValue(message) {
     this.hasNoValue(message);
+  }
+
+  /**
+   * Assert an [HTMLElement][] matching the `selector` is visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isVisible();
+   *
+   */
+  isVisible(message) {
+    let element = this.findTargetElement();
+    if (!element) return;
+
+    let result = visible(element);
+    let actual = result
+      ? `Element ${this.target} is visible`
+      : `Element ${this.target} is not visible`;
+    let expected = `Element ${this.target} is visible`;
+
+    if (!message) {
+      message = expected;
+    }
+
+    this.pushResult({ result, actual, expected, message });
+  }
+
+  /**
+   * Assert an [HTMLElement][] matching the `selector` is not visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isNotVisible();
+   *
+   */
+  isNotVisible(message) {
+    let element = this.findTargetElement();
+    if (!element) return;
+
+    let result = !visible(element);
+    let actual = result
+      ? `Element ${this.target} is not visible`
+      : `Element ${this.target} is visible`;
+    let expected = `Element ${this.target} is not visible`;
+
+    if (!message) {
+      message = expected;
+    }
+
+    this.pushResult({ result, actual, expected, message });
   }
 
   /**

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -5,8 +5,9 @@ import isChecked from './assertions/is-checked';
 import isNotChecked from './assertions/is-not-checked';
 import isRequired from './assertions/is-required';
 import isNotRequired from './assertions/is-not-required';
+import isVisible from './assertions/is-visible';
+import isNotVisible from './assertions/is-not-visible';
 
-import visible from './helpers/visible';
 import elementToString from './helpers/element-to-string';
 import collapseWhitespace from './helpers/collapse-whitespace';
 
@@ -135,6 +136,34 @@ export default class DOMAssertions {
    */
   isNotRequired(message) {
     isNotRequired.call(this, message);
+  }
+
+  /**
+   * Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+   * `selector` is visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isVisible();
+   *
+   */
+  isVisible(message) {
+    isVisible.call(this, message);
+  }
+
+  /**
+   *  Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+   * `selector` is not visible.
+   *
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.foo').isNotVisible();
+   *
+   */
+  isNotVisible(message) {
+    isNotVisible.call(this, message);
   }
 
   /**
@@ -573,58 +602,6 @@ export default class DOMAssertions {
 
   lacksValue(message) {
     this.hasNoValue(message);
-  }
-
-  /**
-   * Assert an [HTMLElement][] matching the `selector` is visible.
-   *
-   * @param {string?} message
-   *
-   * @example
-   * assert.dom('.foo').isVisible();
-   *
-   */
-  isVisible(message) {
-    let element = this.findTargetElement();
-    if (!element) return;
-
-    let result = visible(element);
-    let actual = result
-      ? `Element ${this.target} is visible`
-      : `Element ${this.target} is not visible`;
-    let expected = `Element ${this.target} is visible`;
-
-    if (!message) {
-      message = expected;
-    }
-
-    this.pushResult({ result, actual, expected, message });
-  }
-
-  /**
-   * Assert an [HTMLElement][] matching the `selector` is not visible.
-   *
-   * @param {string?} message
-   *
-   * @example
-   * assert.dom('.foo').isNotVisible();
-   *
-   */
-  isNotVisible(message) {
-    let element = this.findTargetElement();
-    if (!element) return;
-
-    let result = !visible(element);
-    let actual = result
-      ? `Element ${this.target} is not visible`
-      : `Element ${this.target} is visible`;
-    let expected = `Element ${this.target} is not visible`;
-
-    if (!message) {
-      message = expected;
-    }
-
-    this.pushResult({ result, actual, expected, message });
   }
 
   /**

--- a/lib/assertions/is-not-visible.js
+++ b/lib/assertions/is-not-visible.js
@@ -1,0 +1,18 @@
+import visible from '../helpers/visible';
+
+export default function isNotVisible(message) {
+  let element = this.findTargetElement();
+  if (!element) return;
+
+  let result = !visible(element);
+  let actual = result
+    ? `Element ${this.target} is not visible`
+    : `Element ${this.target} is visible`;
+  let expected = `Element ${this.target} is not visible`;
+
+  if (!message) {
+    message = expected;
+  }
+
+  this.pushResult({ result, actual, expected, message });
+}

--- a/lib/assertions/is-visible.js
+++ b/lib/assertions/is-visible.js
@@ -1,0 +1,18 @@
+import visible from '../helpers/visible';
+
+export default function isVisible(message) {
+  let element = this.findTargetElement();
+  if (!element) return;
+
+  let result = visible(element);
+  let actual = result
+    ? `Element ${this.target} is visible`
+    : `Element ${this.target} is not visible`;
+  let expected = `Element ${this.target} is visible`;
+
+  if (!message) {
+    message = expected;
+  }
+
+  this.pushResult({ result, actual, expected, message });
+}

--- a/lib/helpers/visible.js
+++ b/lib/helpers/visible.js
@@ -2,5 +2,5 @@
 // https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
 
 export default function visible(el) {
-  return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+  return el.offsetWidth !== 0 || el.offsetHeight !== 0 || el.getClientRects().length !== 0;
 }

--- a/lib/helpers/visible.js
+++ b/lib/helpers/visible.js
@@ -1,0 +1,6 @@
+// Visible logic based on jQuery's
+// https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
+
+export default function visible(el) {
+  return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+}

--- a/lib/helpers/visible.js
+++ b/lib/helpers/visible.js
@@ -2,5 +2,5 @@
 // https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
 
 export default function visible(el) {
-  return el.offsetWidth !== 0 || el.offsetHeight !== 0 || el.getClientRects().length !== 0;
+  return el !== null && (el.offsetWidth !== 0 || el.offsetHeight !== 0 || el.getClientRects().length !== 0);
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:ember": "ember test",
-    "test:watch": "jest --watchAll --notify"
+    "test:watch": "jest --watchAll --notify",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand"
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.0",

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -4,7 +4,7 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | qunit-dom');
 
 test('qunit-dom assertions are available', function(assert) {
-  assert.expect(11);
+  assert.expect(12);
 
   assert.ok(assert.dom, 'assert.dom is available');
   assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -4,7 +4,7 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | qunit-dom');
 
 test('qunit-dom assertions are available', function(assert) {
-  assert.expect(7);
+  assert.expect(11);
 
   assert.ok(assert.dom, 'assert.dom is available');
   assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');
@@ -18,5 +18,12 @@ test('qunit-dom assertions are available', function(assert) {
     assert.dom('#title').exists();
     assert.dom('#subtitle').doesNotExist();
     assert.dom('#title').hasText('Welcome to Ember');
+
+    // isVisible/isNotVisible tests
+    assert.dom('#title').isVisible();
+    assert.dom('#display-block').isVisible();
+    assert.dom('#display-none').isNotVisible();
+    assert.dom('#display-descendant').isNotVisible();
+    assert.dom('#hidden-input').isNotVisible();
   });
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,11 @@
 <h2 id="title">
   Welcome to <b>Ember</b>
 </h2>
+<p id="display-none" style="display: none;">You can't see me.</p>
+<div style="display: none;">
+  <p id="display-descendant" style="display: block;">You can't see me.</p>
+</div>
+<p id="display-block" style="display: block;">You can see me.</p>
+<input id="hidden-input" type="hidden">
 
 {{outlet}}


### PR DESCRIPTION
This PR supersedes #54 and is a continuation of Pat's work. I'm just trying to help push this in as I find it to be a very useful feature.

From @patocallaghan's PR:

"Fixes #52

Adds isVisible and isNotVisible assertion helpers.

Visibility is modelled off of jQuery's :visible logic in jQuery 3.0 https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13

As mentioned in the issue you may decide not to merge this. If you do, I can then update the README information."