### PR TITLE
Adding new alias for hasText called matchesText

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -379,6 +379,8 @@ export default class DOMAssertions {
    *
    * `expected` can also be a regular expression.
    *
+   * **Aliases:** `matchesText`
+   *
    * @param {string|RegExp} expected
    * @param {string?} message
    *
@@ -432,6 +434,10 @@ export default class DOMAssertions {
     } else {
       throw new TypeError(`You must pass a string or Regular Expression to "hasText". You passed ${expected}.`);
     }
+  }
+
+  matchesText(expected, message) {
+    this.hasText(expected, message);
   }
 
   /**


### PR DESCRIPTION
`hasText` is a little confusing and strikes me as an inclusion rather than a strict comparison. I think `matchesText` is more explicit in calling that out.  I'm assuming the documentation change in API.md should come out after the next release and not with this PR.

This is my first open source contribution :) please let me know if there is anything else I'd have to change anywhere else!