### PR TITLE
Added `hasEmptyAttribute`

### DIFF
--- a/lib/__tests__/has-empty-attribute.js
+++ b/lib/__tests__/has-empty-attribute.js
@@ -1,0 +1,89 @@
+/* eslint-env jest */
+
+import TestAssertions from "../helpers/test-assertions";
+
+describe('assert.dom(...).hasEmptyAttribute()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+
+    document.body.innerHTML = '<button class="share" checked></button>';
+  });
+
+  test('succeeds for attribute without value', () => {
+    assert.dom('.share').hasAttribute('checked', '');
+    assert.dom('.share').hasEmptyAttribute('checked');
+    assert.dom(document.querySelector('.share')).hasEmptyAttribute('checked');
+
+    expect(assert.results).toEqual([{
+      actual: 'Element .share has attribute "checked" with value ""',
+      expected: 'Element .share has attribute "checked" with value ""',
+      message: 'Element .share has attribute "checked" with value ""',
+      result: true,
+    }, {
+      actual: 'Element .share has attribute "checked" with value ""',
+      expected: 'Element .share has attribute "checked" with value ""',
+      message: 'Element .share has attribute "checked" with value ""',
+      result: true,
+    }, {
+      actual: 'Element button.share[checked] has attribute "checked" with value ""',
+      expected: 'Element button.share[checked] has attribute "checked" with value ""',
+      message: 'Element button.share[checked] has attribute "checked" with value ""',
+      result: true,
+    }]);
+  });
+
+  test('fails for non-empty attribute', () => {
+    document.body.innerHTML = '<button class="share" checked=true></button>';
+
+    assert.dom('.share').hasEmptyAttribute('checked');
+    assert.dom(document.querySelector('.share')).hasEmptyAttribute('checked');
+
+    expect(assert.results).toEqual([{
+      actual: 'Element .share has attribute "checked" with value "true"',
+      expected: 'Element .share has attribute "checked" with value ""',
+      message: 'Element .share has attribute "checked" with value ""',
+      result: false,
+    }, {
+      actual: 'Element button.share[checked="true"] has attribute "checked" with value "true"',
+      expected: 'Element button.share[checked="true"] has attribute "checked" with value ""',
+      message: 'Element button.share[checked="true"] has attribute "checked" with value ""',
+      result: false,
+    }]);
+  });
+
+  test('fails for missing attribute', () => {
+    assert.dom('.share').hasEmptyAttribute('disabled');
+    assert.dom(document.querySelector('.share')).hasEmptyAttribute('disabled');
+
+    expect(assert.results).toEqual([{
+      actual: 'Element .share does not have attribute "disabled"',
+      expected: 'Element .share has attribute "disabled" with value ""',
+      message: 'Element .share has attribute "disabled" with value ""',
+      result: false,
+    }, {
+      actual: 'Element button.share[checked] does not have attribute "disabled"',
+      expected: 'Element button.share[checked] has attribute "disabled" with value ""',
+      message: 'Element button.share[checked] has attribute "disabled" with value ""',
+      result: false,
+    }]);
+  });
+
+  test('fails for missing element', () => {
+    assert.dom('#missing').hasEmptyAttribute('foo');
+
+    expect(assert.results).toEqual([{
+      message: 'Element #missing exists',
+      result: false,
+    }]);
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).hasAttribute('foo')).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).hasAttribute('foo')).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).hasAttribute('foo')).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).hasAttribute('foo')).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).hasAttribute('foo')).toThrow('Unexpected Parameter: [object HTMLDocument]');
+  });
+});

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -247,6 +247,22 @@ export default class DOMAssertions {
     }
   }
 
+  /**
+   * Assert that the [HTMLElement][] has an empty attribute, i.e. an attribute that
+   * does not have a value.
+   *
+   * @param {string} name
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('button.select').hasEmptyAttribute('checked', 'The select button is checked');
+   *
+   * @see {@link #hasAttribute}
+   */
+  hasEmptyAttribute(name, message) {
+    this.hasAttribute(name, '', message);
+  }
+
   isDisabled(message) {
     let element = this.findTargetElement();
 


### PR DESCRIPTION
👋 In an increasing number of cases in the codebase I work on mostly, we are starting to check if a given DOM element has an attribute, and we're big fans of adding messages whenever possible to the assertion.

`hasAttribute` is great, but (obviously) only accepts a `message` argument if it's the third parameter in `hasAttribute(name, value, message)`.

Given that we increasingly need to check for empty attributes (e.g.: custom data attributes), it would be great if instead of
`hasAttribute('myName', '', 'this DOM has myName')`
we could have
`hasEmptyAttribute('myName', 'this DOM has myName')`

--

When working on this change, I based my code on `hasAnyText`, so `hasEmptyAttribute` is almost an alias of `hasAttribute` and gets its own test file.

Let me know what you think.