### PR TITLE
Strip non-breaking and zero-width spaces in `collapseWhitespace` helper

### DIFF
--- a/lib/helpers/collapse-whitespace.js
+++ b/lib/helpers/collapse-whitespace.js
@@ -1,7 +1,7 @@
 export default function collapseWhitespace(string) {
   return string
-    .replace(/[\t\r\n]/g, ' ')
-    .replace(/ +/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\u200b+/g, '')
     .replace(/^ /, '')
     .replace(/ $/, '');
 }

--- a/lib/helpers/collapse-whitespace.test.js
+++ b/lib/helpers/collapse-whitespace.test.js
@@ -10,6 +10,7 @@ const TESTS = [
   [' a b c ', 'a b c'],
   [' a\r\n b c ', 'a b c'],
   ['\n    foo equals\n    bar\n  ', 'foo equals bar'],
+  ['a\xa0b\u200bc', 'a bc'],
 ];
 
 TESTS.forEach(it => {


### PR DESCRIPTION
We noticed when migrating some assertions in our tests from an internal whitespace helper to qunit-dom's `hasText` that we had some failures. It was showing a mismatch due to `collapseWhitespace` not collapsing non-breaking spaces and zero-width spaces.