### PR TITLE
Changes element assertion from 'exists' to 'should exist'

### DIFF
--- a/lib/__tests__/does-not-have-attribute.js
+++ b/lib/__tests__/does-not-have-attribute.js
@@ -66,7 +66,7 @@ describe('assert.dom(...).doesNotHaveAttribute()', () => {
     assert.dom('#missing').doesNotHaveAttribute('disabled');
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/does-not-have-class.js
+++ b/lib/__tests__/does-not-have-class.js
@@ -49,7 +49,7 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
     assert.dom('#missing').doesNotHaveClass('foo');
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/does-not-include-text.js
+++ b/lib/__tests__/does-not-include-text.js
@@ -56,7 +56,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom(null).doesNotIncludeText('foo');
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -93,7 +93,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
       assert.dom('h2').doesNotIncludeText('foo');
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 exists',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/exists.js
+++ b/lib/__tests__/exists.js
@@ -16,9 +16,9 @@ describe('assert.dom(...).exists()', () => {
       assert.dom('h1').exists();
 
       expect(assert.results).toEqual([{
-        actual: 'Element h1 exists',
-        expected: 'Element h1 exists',
-        message: 'Element h1 exists',
+        actual: 'Element h1 should exist',
+        expected: 'Element h1 should exist',
+        message: 'Element h1 should exist',
         result: true,
       }]);
     });
@@ -30,8 +30,8 @@ describe('assert.dom(...).exists()', () => {
 
       expect(assert.results).toEqual([{
         actual: 'Element h2 does not exist',
-        expected: 'Element h2 exists',
-        message: 'Element h2 exists',
+        expected: 'Element h2 should exist',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });
@@ -44,8 +44,8 @@ describe('assert.dom(...).exists()', () => {
       assert.dom('h1').exists('foo');
 
       expect(assert.results).toEqual([{
-        actual: 'Element h1 exists',
-        expected: 'Element h1 exists',
+        actual: 'Element h1 should exist',
+        expected: 'Element h1 should exist',
         message: 'foo',
         result: true,
       }]);

--- a/lib/__tests__/exists.js
+++ b/lib/__tests__/exists.js
@@ -16,9 +16,9 @@ describe('assert.dom(...).exists()', () => {
       assert.dom('h1').exists();
 
       expect(assert.results).toEqual([{
-        actual: 'Element h1 should exist',
-        expected: 'Element h1 should exist',
-        message: 'Element h1 should exist',
+        actual: 'Element h1 exists',
+        expected: 'Element h1 exists',
+        message: 'Element h1 exists',
         result: true,
       }]);
     });
@@ -30,8 +30,8 @@ describe('assert.dom(...).exists()', () => {
 
       expect(assert.results).toEqual([{
         actual: 'Element h2 does not exist',
-        expected: 'Element h2 should exist',
-        message: 'Element h2 should exist',
+        expected: 'Element h2 exists',
+        message: 'Element h2 exists',
         result: false,
       }]);
     });
@@ -44,8 +44,8 @@ describe('assert.dom(...).exists()', () => {
       assert.dom('h1').exists('foo');
 
       expect(assert.results).toEqual([{
-        actual: 'Element h1 should exist',
-        expected: 'Element h1 should exist',
+        actual: 'Element h1 exists',
+        expected: 'Element h1 exists',
         message: 'foo',
         result: true,
       }]);

--- a/lib/__tests__/has-any-text.js
+++ b/lib/__tests__/has-any-text.js
@@ -10,7 +10,7 @@ describe('assert.dom(...).hasAnyText()', () => {
 
     document.body.innerHTML = '<button class="share"></button>';
   });
-  
+
   test('succeeds for correct content', () => {
     document.querySelector('button.share').textContent = 'Share';
 
@@ -51,7 +51,7 @@ describe('assert.dom(...).hasAnyText()', () => {
     assert.dom('#missing').hasAnyText();
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/has-any-value.js
+++ b/lib/__tests__/has-any-value.js
@@ -52,7 +52,7 @@ describe('assert.dom(...).hasAnyValue()', () => {
     assert.dom('#missing').hasAnyValue();
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/has-attribute.js
+++ b/lib/__tests__/has-attribute.js
@@ -193,7 +193,7 @@ describe('assert.dom(...).hasAttribute()', () => {
     assert.dom('#missing').hasAttribute('foo');
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/has-class.js
+++ b/lib/__tests__/has-class.js
@@ -49,7 +49,7 @@ describe('assert.dom(...).hasClass()', () => {
     assert.dom('#missing').hasClass('foo');
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/has-no-value.js
+++ b/lib/__tests__/has-no-value.js
@@ -51,7 +51,7 @@ describe('assert.dom(...).hasNoValue()', () => {
     assert.dom('#missing').hasNoValue();
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/has-text-regex.js
+++ b/lib/__tests__/has-text-regex.js
@@ -67,7 +67,7 @@ describe('assert.dom(...).hasText()', () => {
       assert.dom(null).hasText(/fo+/);
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -115,7 +115,7 @@ describe('assert.dom(...).hasText()', () => {
       assert.dom('h2').hasText(/fo+/);
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 exists',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/has-text.js
+++ b/lib/__tests__/has-text.js
@@ -56,7 +56,7 @@ describe('assert.dom(...).hasText()', () => {
       assert.dom(null).hasText('Welcome to QUnit');
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -93,7 +93,7 @@ describe('assert.dom(...).hasText()', () => {
       assert.dom('#missing').hasText('foo');
 
       expect(assert.results).toEqual([{
-        message: 'Element #missing exists',
+        message: 'Element #missing should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/has-value.js
+++ b/lib/__tests__/has-value.js
@@ -183,7 +183,7 @@ describe('assert.dom(...).hasValue()', () => {
     assert.dom('#missing').hasValue('foo');
 
     expect(assert.results).toEqual([{
-      message: 'Element #missing exists',
+      message: 'Element #missing should exist',
       result: false,
     }]);
   });

--- a/lib/__tests__/includes-text.js
+++ b/lib/__tests__/includes-text.js
@@ -67,7 +67,7 @@ describe('assert.dom(...).includesText()', () => {
       assert.dom(null).includesText('foo');
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -115,7 +115,7 @@ describe('assert.dom(...).includesText()', () => {
       assert.dom('h2').includesText('foo');
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 exists',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-checked.js
+++ b/lib/__tests__/is-checked.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isChecked()', () => {
       assert.dom(null).isChecked();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -95,7 +95,7 @@ describe('assert.dom(...).isChecked()', () => {
       assert.dom('input[type="password"]').isChecked();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-disabled.js
+++ b/lib/__tests__/is-disabled.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isDisabled()', () => {
       assert.dom(null).isDisabled();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -109,7 +109,7 @@ describe('assert.dom(...).isDisabled()', () => {
       assert.dom('input[type="password"]').isDisabled();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-focused.js
+++ b/lib/__tests__/is-focused.js
@@ -60,7 +60,7 @@ describe('assert.dom(...).isFocused()', () => {
       assert.dom(null).isFocused();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -101,7 +101,7 @@ describe('assert.dom(...).isFocused()', () => {
       assert.dom('input[type="password"]').isFocused();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-not-checked.js
+++ b/lib/__tests__/is-not-checked.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isNotChecked()', () => {
       assert.dom(null).isNotChecked();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -95,7 +95,7 @@ describe('assert.dom(...).isNotChecked()', () => {
       assert.dom('input[type="password"]').isNotChecked();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-not-disabled.js
+++ b/lib/__tests__/is-not-disabled.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isNotDisabled()', () => {
       assert.dom(null).isNotDisabled();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -109,7 +109,7 @@ describe('assert.dom(...).isNotDisabled()', () => {
       assert.dom('input[type="password"]').isNotDisabled();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-not-focused.js
+++ b/lib/__tests__/is-not-focused.js
@@ -54,7 +54,7 @@ describe('assert.dom(...).isNotFocused()', () => {
       assert.dom(null).isNotFocused();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -91,7 +91,7 @@ describe('assert.dom(...).isNotFocused()', () => {
       assert.dom('input[type="password"]').isNotFocused();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-not-required.js
+++ b/lib/__tests__/is-not-required.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isNotRequired()', () => {
       assert.dom(null).isNotRequired();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -95,7 +95,7 @@ describe('assert.dom(...).isNotRequired()', () => {
       assert.dom('input[type="password"]').isNotRequired();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-not-visible.js
+++ b/lib/__tests__/is-not-visible.js
@@ -16,7 +16,7 @@ describe('assert.dom(...).isNotVisible()', () => {
       assert.dom('h2').isNotVisible();
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 exists',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-required.js
+++ b/lib/__tests__/is-required.js
@@ -57,7 +57,7 @@ describe('assert.dom(...).isRequired()', () => {
       assert.dom(null).isRequired();
 
       expect(assert.results).toEqual([{
-        message: 'Element <unknown> exists',
+        message: 'Element <unknown> should exist',
         result: false,
       }]);
     });
@@ -95,7 +95,7 @@ describe('assert.dom(...).isRequired()', () => {
       assert.dom('input[type="password"]').isRequired();
 
       expect(assert.results).toEqual([{
-        message: 'Element input[type="password"] exists',
+        message: 'Element input[type="password"] should exist',
         result: false,
       }]);
     });

--- a/lib/__tests__/is-visible.js
+++ b/lib/__tests__/is-visible.js
@@ -16,7 +16,7 @@ describe('assert.dom(...).isVisible()', () => {
       assert.dom('h2').isVisible();
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 exists',
+        message: 'Element h2 should exist',
         result: false,
       }]);
     });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -677,7 +677,7 @@ export default class DOMAssertions {
    */
   findTargetElement() {
     if (this.target === null) {
-      let message = `Element <unknown> exists`;
+      let message = `Element <unknown> should exist`;
       this.pushResult({ message, result: false });
       return null;
     }
@@ -686,7 +686,7 @@ export default class DOMAssertions {
       let el = this.rootElement.querySelector(this.target);
 
       if (el === null) {
-        let message = `Element ${this.target || '<unknown>'} exists`;
+        let message = `Element ${this.target || '<unknown>'} should exist`;
         this.pushResult({ message, result: false });
       }
 

--- a/lib/assertions/exists.js
+++ b/lib/assertions/exists.js
@@ -41,7 +41,7 @@ export default function exists(options, message) {
 
 function format(selector, num) {
   if (num === undefined || num === null) {
-    return `Element ${selector} exists`;
+    return `Element ${selector} should exist`;
   } else if (num === 0) {
     return `Element ${selector} does not exist`;
   } else if (num === 1) {

--- a/lib/assertions/exists.js
+++ b/lib/assertions/exists.js
@@ -41,7 +41,7 @@ export default function exists(options, message) {
 
 function format(selector, num) {
   if (num === undefined || num === null) {
-    return `Element ${selector} should exist`;
+    return `Element ${selector} exists`;
   } else if (num === 0) {
     return `Element ${selector} does not exist`;
   } else if (num === 1) {


### PR DESCRIPTION
Updating the assertion message when an element is not present but is expected to be so
- the old assertion was Element <el|unknown> exists, which was mildly confusing as it was often accompanied with a test failure, but asserted an error in the positive voice
- the new assertion message is Element <el|unknown> should exist, which is an assertion as to the expected state

This PR addresses #84.