### PR TITLE
Let `isNotVisible()` pass if the element does not exist

### DIFF
--- a/API.md
+++ b/API.md
@@ -189,14 +189,15 @@ assert.dom('input[type="text"]').isNotRequired();
 
 ### isVisible
 
-Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-`selector` is visible. Visibility is determined with the hueristic
-used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
-specifically:
+-   **See: [#isNotVisible](#isNotVisible)**
 
--   is the element's offsetWidth non-zero
--   is the element's offsetHeight non-zero
--   is the length of an element's DOMRect objects found via getClientRects() non-zero
+Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+`selector` exists and is visible.
+
+Visibility is determined by asserting that:
+
+-   the element's offsetWidth and offsetHeight are non-zero
+-   any of the element's DOMRect objects have a non-zero size
 
 Additionally, visibility in this case means that the element is visible on the page,
 but not necessarily in the viewport.
@@ -213,14 +214,15 @@ assert.dom('.foo').isVisible();
 
 ### isNotVisible
 
-Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-`selector` is not visible. Visibility is determined with the hueristic
-used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
-specifically:
+-   **See: [#isVisible](#isVisible)**
 
--   is the element's offsetWidth non-zero
--   is the element's offsetHeight non-zero
--   is the length of an element's DOMRect objects found via getClientRects() non-zero
+Assert that the [HTMLElement][] or an [HTMLElement][] matching the
+`selector` does not exist or is not visible on the page.
+
+Visibility is determined by asserting that:
+
+-   the element's offsetWidth or offsetHeight are zero
+-   all of the element's DOMRect objects have a size of zero
 
 Additionally, visibility in this case means that the element is visible on the page,
 but not necessarily in the viewport.

--- a/lib/__tests__/is-not-visible.js
+++ b/lib/__tests__/is-not-visible.js
@@ -2,6 +2,14 @@
 
 import TestAssertions from '../helpers/test-assertions';
 
+/*
+ * JSDom based tests aren't able to discern visibility as we define it. Specifically,
+ * the JSDom tests don't do layouting, therefore calculating `offsetWdith` or `offsetHeight`
+ * won't work. As a result, we need to use Ember's test infrastructure to correctly assess
+ * visibility, as those tests run in a browser environment.
+ *
+ * Tests for the success cases of isNotVisible can be found in tests/acceptance/qunit-dom-test.js
+ */
 describe('assert.dom(...).isNotVisible()', () => {
   let assert;
 
@@ -10,14 +18,16 @@ describe('assert.dom(...).isNotVisible()', () => {
   });
 
   describe('selector only', () => {
-    test('fails if element is missing', () => {
+    test('succeeds if element is missing', () => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
 
       assert.dom('h2').isNotVisible();
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 should exist',
-        result: false,
+        actual: 'Element h2 is not visible',
+        expected: 'Element h2 is not visible',
+        message: 'Element h2 is not visible',
+        result: true,
       }]);
     });
   });

--- a/lib/__tests__/is-visible.js
+++ b/lib/__tests__/is-visible.js
@@ -2,6 +2,14 @@
 
 import TestAssertions from '../helpers/test-assertions';
 
+/*
+ * JSDom based tests aren't able to discern visibility as we define it. Specifically,
+ * the JSDom tests don't do layouting, therefore calculating `offsetWdith` or `offsetHeight`
+ * won't work. As a result, we need to use Ember's test infrastructure to correctly assess
+ * visibility, as those tests run in a browser environment.
+ *
+ * Tests for the success cases of isVisible can be found in tests/acceptance/qunit-dom-test.js
+ */
 describe('assert.dom(...).isVisible()', () => {
   let assert;
 
@@ -16,8 +24,10 @@ describe('assert.dom(...).isVisible()', () => {
       assert.dom('h2').isVisible();
 
       expect(assert.results).toEqual([{
-        message: 'Element h2 should exist',
-        result: false,
+        actual: 'Element h2 is not visible',
+        expected: 'Element h2 is visible',
+        message: 'Element h2 is visible',
+        result: false
       }]);
     });
   });

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -673,21 +673,37 @@ export default class DOMAssertions {
   }
 
   /**
+   * Finds a valid HTMLElement from target, or pushes a failing assertion if a valid
+   * element is not found.
    * @private
+   * @returns a valid HTMLElement, or null
    */
   findTargetElement() {
-    if (this.target === null) {
-      let message = `Element <unknown> should exist`;
+    let el = this.findElement();
+
+    if (el === null) {
+      let message = `Element ${this.target || '<unknown>'} should exist`;
       this.pushResult({ message, result: false });
       return null;
     }
 
-    if (typeof this.target === 'string') {
+    return el;
+  }
+
+  /**
+   * Finds a valid HTMLElement from target
+   * @private
+   * @returns a valid HTMLElement, or null
+   * @throws TypeError will be thrown if target is an unrecognized type
+   */
+  findElement() {
+    if (this.target === null) {
+      return null;
+    } else if (typeof this.target === 'string') {
       let el = this.rootElement.querySelector(this.target);
 
       if (el === null) {
-        let message = `Element ${this.target || '<unknown>'} should exist`;
-        this.pushResult({ message, result: false });
+        return null;
       }
 
       return el;

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -676,7 +676,7 @@ export default class DOMAssertions {
    * Finds a valid HTMLElement from target, or pushes a failing assertion if a valid
    * element is not found.
    * @private
-   * @returns a valid HTMLElement, or null
+   * @returns (HTMLElement|null) a valid HTMLElement, or null
    */
   findTargetElement() {
     let el = this.findElement();
@@ -693,7 +693,7 @@ export default class DOMAssertions {
   /**
    * Finds a valid HTMLElement from target
    * @private
-   * @returns a valid HTMLElement, or null
+   * @returns (HTMLElement|null) a valid HTMLElement, or null
    * @throws TypeError will be thrown if target is an unrecognized type
    */
   findElement() {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -149,13 +149,12 @@ export default class DOMAssertions {
 
   /**
    * Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-   * `selector` is visible. Visibility is determined with the heuristic
-   * used in [jQuery's :visible pseudo-selector](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12),
-   * specifically:
+   * `selector` exists and is visible.
    *
-   * - the element's offsetWidth is non-zero
-   * - the element's offsetHeight is non-zero
-   * - the length of an element's DOMRect objects found via getClientRects() is non-zero
+   * Visibility is determined by asserting that:
+   *
+   * - the element's offsetWidth and offsetHeight are non-zero
+   * - any of the element's DOMRect objects have a non-zero size
    *
    * Additionally, visibility in this case means that the element is visible on the page,
    * but not necessarily in the viewport.
@@ -174,15 +173,12 @@ export default class DOMAssertions {
 
   /**
    * Assert that the [HTMLElement][] or an [HTMLElement][] matching the
-   * `selector` is not visible on the page.
+   * `selector` does not exist or is not visible on the page.
    *
-   * Visibility is determined with the heuristic used in jQuery's
-   * [`:visible`](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/src/css/hiddenVisibleSelectors.js#L12)
-   * pseudo-selector:
+   * Visibility is determined by asserting that:
    *
-   * - the element's offsetWidth is non-zero
-   * - the element's offsetHeight is non-zero
-   * - the length of an element's DOMRect objects found via getClientRects() is non-zero
+   * - the element's offsetWidth or offsetHeight are zero
+   * - all of the element's DOMRect objects have a size of zero
    *
    * Additionally, visibility in this case means that the element is visible on the page,
    * but not necessarily in the viewport.

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -695,14 +695,9 @@ export default class DOMAssertions {
   findElement() {
     if (this.target === null) {
       return null;
+
     } else if (typeof this.target === 'string') {
-      let el = this.rootElement.querySelector(this.target);
-
-      if (el === null) {
-        return null;
-      }
-
-      return el;
+      return this.rootElement.querySelector(this.target);
 
     } else if (this.target instanceof Element) {
       return this.target;

--- a/lib/assertions/is-not-visible.js
+++ b/lib/assertions/is-not-visible.js
@@ -1,8 +1,7 @@
 import visible from '../helpers/visible';
 
 export default function isNotVisible(message) {
-  let element = this.findTargetElement();
-  if (!element) return;
+  let element = this.findElement();
 
   let result = !visible(element);
   let actual = result

--- a/lib/assertions/is-visible.js
+++ b/lib/assertions/is-visible.js
@@ -1,8 +1,7 @@
 import visible from '../helpers/visible';
 
 export default function isVisible(message) {
-  let element = this.findTargetElement();
-  if (!element) return;
+  let element = this.findElement();
 
   let result = visible(element);
   let actual = result

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -4,7 +4,7 @@ import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 moduleForAcceptance('Acceptance | qunit-dom');
 
 test('qunit-dom assertions are available', function(assert) {
-  assert.expect(12);
+  assert.expect(13);
 
   assert.ok(assert.dom, 'assert.dom is available');
   assert.ok(assert.dom('.foo').includesText, 'assert.dom(...).includesText is available');
@@ -19,12 +19,15 @@ test('qunit-dom assertions are available', function(assert) {
     assert.dom('#subtitle').doesNotExist();
     assert.dom('#title').hasText('Welcome to Ember');
 
-    // JSDom based tests aren't able to discern visibility as we define it. Specifically,
-    // the JSDom tests don't do layouting, therefore calculating `offsetWdith` or `offsetHeight`
-    // won't work. As a result, we need to use Ember's test infrastructure to correctly assess
-    // visibility, as those tests run in a browser environment.
+    /*
+     * JSDom based tests aren't able to discern visibility as we define it. Specifically,
+     * the JSDom tests don't do layouting, therefore calculating `offsetWdith` or `offsetHeight`
+     * won't work. As a result, we need to use Ember's test infrastructure to correctly assess
+     * visibility, as those tests run in a browser environment.
+     */
     assert.dom('#title').isVisible();
     assert.dom('#display-block').isVisible();
+    assert.dom('#missing').isNotVisible();
     assert.dom('#display-none').isNotVisible();
     assert.dom('#display-descendant').isNotVisible();
     assert.dom('#hidden-input').isNotVisible();


### PR DESCRIPTION
Fixing the logic in is-visible/is-not-visible to account for when elements are missing in the DOM.
These assertions would trigger the Element <el> exists assertion that was triggered when an element was not found in the DOM, regardless of correctness
- `is-visible` should **pass** in the case where the element **exists** and is visible
- `is-visible` should **fail** in the case where the element **doesn't exist** or is not visible
- `is-not-visible` should **pass** in the case where the element **doesn't exist** or is not visible
- `is-not-visible` should **fail** in the case where the element **exists** and is visible