### PR TITLE
Collapse whitespace for `includesText` assertion

### DIFF
--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -73,6 +73,57 @@ describe('assert.dom(...).includesText()', () => {
     });
   });
 
+  describe('with HTMLElement with irregular-spacing', () => {
+    let element;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<h1 class="baz">foo\n  <span>bar</span>\n</h1>baz';
+      element = document.querySelector('h1');
+    });
+
+    test('succeeds for correct content', () => {
+      assert.dom(element).includesText('foo bar');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar',
+        expected: 'foo bar',
+        message: 'Element h1.baz has text containing "foo bar"',
+        result: true,
+      }]);
+    });
+
+    test('succeeds for correct partial content', () => {
+      assert.dom(element).includesText('oo b');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar',
+        expected: 'oo b',
+        message: 'Element h1.baz has text containing "oo b"',
+        result: true,
+      }]);
+    });
+
+    test('fails for wrong content', () => {
+      assert.dom(element).includesText('baz');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar',
+        expected: 'baz',
+        message: 'Element h1.baz has text containing "baz"',
+        result: false,
+      }]);
+    });
+
+    test('fails for missing element', () => {
+      assert.dom(null).includesText('foo');
+
+      expect(assert.results).toEqual([{
+        message: 'Element <unknown> should exist',
+        result: false,
+      }]);
+    });
+  });
+
   describe('with selector', () => {
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -556,8 +556,9 @@ export default class DOMAssertions {
     let element = this.findTargetElement();
     if (!element) return;
 
-    let result = element.textContent.indexOf(text) !== -1;
-    let actual = element.textContent;
+    let collapsedText = collapseWhitespace(element.textContent);
+    let result = collapsedText.indexOf(text) !== -1;
+    let actual = collapsedText;
     let expected = text;
 
     if (!message) {
@@ -594,7 +595,8 @@ export default class DOMAssertions {
     let element = this.findTargetElement();
     if (!element) return;
 
-    let result = element.textContent.indexOf(text) === -1;
+    let collapsedText = collapseWhitespace(element.textContent);
+    let result = collapsedText.indexOf(text) === -1;
     let expected = `Element ${this.targetDescription} does not include text "${text}"`;
     let actual = expected;
 


### PR DESCRIPTION
Trim white-spaces from element text before comparing to expected result

see: #104