### PR TITLE
fix typescript installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ A basic codemod to automatically convert your assertions is available at
 `qunit-dom` includes type definition files, but the way it extends QUnit means
 that you need import it somewhere so that TS and your editor can pick up the
 types. It is recommended to add the following line to your
-`tests/test-helper.js` file:
+`tests/test-helper.ts` file:
 
 ```
 import 'qunit-dom';
 ```
 
+Make sure that you moved `tests/test-helper.js` to a typescript file. Renaming
+is enough therefore.
 
 Contributing
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Typescript does not recognize the type if it's imported in a JavaScript file. Therefore `tests/test-helper.js` has to be renamed to `tests/test-helper.ts`.

Fixes #108