### PR TITLE
Update Node version requirement to `6.* || 8.* || >= 10.*`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^2.9.2"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
CI already runs on Node 6, so this does not need to be updated.

This PR unblocks #117 