### PR TITLE
only install assertions when QUnit is defined

### DIFF
--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -6,7 +6,9 @@ declare global {
   }
 }
 
-QUnit.assert.dom = function(target?: string | Element | null, rootElement?: Element): DOMAssertions {
-  rootElement = rootElement || this.dom.rootElement || document;
-  return new DOMAssertions(target || rootElement, rootElement, this);
-};
+if (typeof QUnit !== 'undefined') {
+  QUnit.assert.dom = function(target?: string | Element | null, rootElement?: Element): DOMAssertions {
+    rootElement = rootElement || this.dom.rootElement || document;
+    return new DOMAssertions(target || rootElement, rootElement, this);
+  };
+}

--- a/vendor/overwrite-qunit-dom-root-element.js
+++ b/vendor/overwrite-qunit-dom-root-element.js
@@ -1,7 +1,9 @@
-Object.defineProperty(QUnit.assert.dom, 'rootElement', {
-  get: function() {
-    return document.querySelector('#ember-testing');
-  },
-  enumerable: true,
-  configurable: true,
-});
+if (typeof QUnit !== 'undefined') {
+  Object.defineProperty(QUnit.assert.dom, 'rootElement', {
+    get: function() {
+      return document.querySelector('#ember-testing');
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
`qunit-dom` was installed for me when I upgraded from ember-cli 3.1 to 3.2. I use mocha so this caused my tests to fail.

```
qunit-dom.js:5 Uncaught ReferenceError: QUnit is not defined
    at qunit-dom.js:5
```
(followed by a bunch of cascading errors)

This change makes qunit-dom a no-op if there is no QUnit.