### PR TITLE
Add `assert.dom(...).hasStyle()` assertion

### DIFF
--- a/API.md
+++ b/API.md
@@ -73,6 +73,9 @@
     -   [hasNoValue](#hasnovalue)
         -   [Parameters](#parameters-22)
         -   [Examples](#examples-22)
+-   [hasStyle](#hasstyle)
+    -   [Parameters](#parameters-23)
+    -   [Examples](#examples-23)
 
 ## assert.dom()
 
@@ -537,4 +540,25 @@ Assert that the `value` property of an [HTMLInputElement](https://developer.mozi
 
 ```javascript
 assert.dom('input.username').hasNoValue();
+```
+
+## hasStyle
+
+-   **See: [#hasClass](#hasClass)**
+
+Assert that the [HTMLElement][] has the `expected` style declarations using
+[`window.getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle).
+
+### Parameters
+
+-   `expected` **[object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
+-   `message` **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)?** 
+
+### Examples
+
+```javascript
+assert.dom('.progress-bar').hasStyle({
+  opacity: 1,
+  display: 'block'
+});
 ```

--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -24,6 +24,25 @@ describe('assert.dom(...).hasStyle()', () => {
     }]);
   });
 
+  test('succeeds for checking styles applied by CSS stylesheets', () => {
+    var styleNode = document.createElement('style');
+    styleNode.innerHTML = '.foo { color: blue }';
+    document.body.appendChild(styleNode);
+    assert.dom('.foo').hasStyle({
+      opacity: '1',
+      width: '200px',
+      'text-align': 'center',
+      color: 'blue',
+    });
+    expect(assert.results).toEqual([{
+      actual: { opacity: '1', width: '200px', 'text-align': 'center', color: 'blue' },
+      expected: { opacity: '1', width: '200px', 'text-align': 'center', color: 'blue' },
+      message: 'Element .foo has style \"{\"opacity\":\"1\",\"width\":\"200px\",\"text-align\":\"center\",\"color\":\"blue\"}\"',
+      result: true,
+    }]);
+    document.body.removeChild(styleNode);
+  });
+
   test('succeeds for partial style checking', () => {
     assert.dom('.foo').hasStyle({
       opacity: '1',

--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -10,17 +10,47 @@ describe('assert.dom(...).hasStyle()', () => {
     document.body.innerHTML = '<div class="foo" style="opacity: 1; width: 200px; text-align: center;">quit-dom ftw!</div>';
   });
 
-  test('works for subset of style assertions', () => {
+  test('succeeds for correct content', () => {
     assert.dom('.foo').hasStyle({
       opacity: '1',
       width: '200px',
       'text-align': 'center',
     });
     expect(assert.results).toEqual([{
-      actual: {opacity: '1', width: '200px', 'text-align': 'center'},
-      expected: {opacity: '1', width: '200px', 'text-align': 'center'},
+      actual: { opacity: '1', width: '200px', 'text-align': 'center' },
+      expected: { opacity: '1', width: '200px', 'text-align': 'center' },
       message: 'Element .foo has style \"{\"opacity\":\"1\",\"width\":\"200px\",\"text-align\":\"center\"}\"',
       result: true,
     }]);
+  });
+
+  test('fails for wrong content', () => {
+    assert.dom('.foo').hasStyle({
+      opacity: 0,
+    });
+    expect(assert.results).toEqual([{
+      actual: { opacity: '1' },
+      expected: { opacity: 0 },
+      message: 'Element .foo has style \"{\"opacity\":0}\"',
+      result: false,
+    }]);
+  });
+
+  test('fails for missing element', () => {
+    assert.dom('#missing').hasStyle({
+      opacity: 0,
+    });
+    expect(assert.results).toEqual([{
+      message: 'Element #missing should exist',
+      result: false,
+    }]);
+  });
+
+  test('throws for unexpected parameter types', () => {
+    expect(() => assert.dom(5).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: 5');
+    expect(() => assert.dom(true).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: true');
+    expect(() => assert.dom(undefined).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: undefined');
+    expect(() => assert.dom({}).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: [object Object]');
+    expect(() => assert.dom(document).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: [object Document]');
   });
 });

--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+
+import TestAssertions from "../helpers/test-assertions";
+
+describe('assert.dom(...).hasStyle()', () => {
+  let assert;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+    document.body.innerHTML = '<div class="foo" style="opacity: 1; width: 200px; text-align: center;">quit-dom ftw!</div>';
+  });
+
+  test('works for subset of style assertions', () => {
+    assert.dom('.foo').hasStyle({
+      opacity: '1',
+      width: '200px',
+      'text-align': 'center',
+    });
+    expect(assert.results).toEqual([{
+      actual: {opacity: '1', width: '200px', 'text-align': 'center'},
+      expected: {opacity: '1', width: '200px', 'text-align': 'center'},
+      message: 'Element .foo has style \"{\"opacity\":\"1\",\"width\":\"200px\",\"text-align\":\"center\"}\"',
+      result: true,
+    }]);
+  });
+});

--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -24,6 +24,18 @@ describe('assert.dom(...).hasStyle()', () => {
     }]);
   });
 
+  test('succeeds for partial style checking', () => {
+    assert.dom('.foo').hasStyle({
+      opacity: '1',
+    });
+    expect(assert.results).toEqual([{
+      actual: { opacity: '1' },
+      expected: { opacity: '1' },
+      message: 'Element .foo has style \"{\"opacity\":\"1\"}\"',
+      result: true,
+    }]);
+  });
+
   test('fails for wrong content', () => {
     assert.dom('.foo').hasStyle({
       opacity: 0,

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -454,12 +454,6 @@ export default class DOMAssertions {
     let result = expectedProperties.every(property => computedStyle[property] === expected[property]);
     let actual = {};
     expectedProperties.forEach(property => actual[property] = computedStyle[property]);
-    for (let property in expected) {
-      actual[property] = computedStyle[property];
-      if (!result) {
-        result = '' + expected[property] === actual[property];
-      }
-    }
     if (!message) {
       message = `Element ${this.targetDescription} has style "${JSON.stringify(expected)}"`;
     }

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -449,11 +449,13 @@ export default class DOMAssertions {
   hasStyle(expected: object, message?: string): void {
     let element = this.findTargetElement();
     if (!element) return;
+    let computedStyle = window.getComputedStyle(element);
+    let expectedProperties = Object.keys(expected);
+    let result = expectedProperties.every(property => computedStyle[property] === expected[property]);
     let actual = {};
-    let result = false;
-    let cssStyleDeclaration = window.getComputedStyle(element);
+    expectedProperties.forEach(property => actual[property] = computedStyle[property]);
     for (let property in expected) {
-      actual[property] = cssStyleDeclaration[property];
+      actual[property] = computedStyle[property];
       if (!result) {
         result = '' + expected[property] === actual[property];
       }

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -431,6 +431,40 @@ export default class DOMAssertions {
   }
 
   /**
+   * Assert that the [HTMLElement][] has the `expected` style declarations using
+   * [`window.getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle).
+   *
+   * @name hasStyle
+   * @param {object} expected
+   * @param {string?} message
+   *
+   * @example
+   * assert.dom('.progress-bar').hasStyle({
+   *   opacity: 1,
+   *   display: 'block'
+   * });
+   *
+   * @see {@link #hasClass}
+   */
+  hasStyle(expected: object, message?: string): void {
+    let element = this.findTargetElement();
+    if (!element) return;
+    let actual = {};
+    let result = false;
+    let cssStyleDeclaration = window.getComputedStyle(element);
+    for (let property in expected) {
+      actual[property] = cssStyleDeclaration[property];
+      if (!result) {
+        result = '' + expected[property] === actual[property];
+      }
+    }
+    if (!message) {
+      message = `Element ${this.targetDescription} has style "${JSON.stringify(expected)}"`;
+    }
+    this.pushResult({ result, actual, expected, message });
+  }
+
+  /**
    * Assert that the text of the {@link HTMLElement} or an {@link HTMLElement}
    * matching the `selector` matches the `expected` text, using the
    * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)


### PR DESCRIPTION
Add assertions for styles like 

```js
assert.dom('.some-element').hasStyle({
  opacity: 1,
  width: '340px',
});
```


Fixes #90 

supersedes #106 