### PR TITLE
Warn user when `includesText` assertion should expect collapsable whitespace

### DIFF
--- a/API.md
+++ b/API.md
@@ -448,6 +448,11 @@ matching the `selector` contains the given `text`, using the
 [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
 attribute.
 
+> Note: This assertion will collapse whitespace in `textContent` before searching.
+> If you would like to assert on a string that _should_ contain line breaks, tabs,
+> more than one space in a row, or starting/ending whitespace, use the [#hasText](#hasText)
+> selector and pass your expected text in as a RegEx pattern.
+
 **Aliases:** `containsText`, `hasTextContaining`
 
 #### Parameters

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -124,6 +124,48 @@ describe('assert.dom(...).includesText()', () => {
     });
   });
 
+  describe('with HTMLElement with expected spacing', () => {
+    let element;
+
+    beforeEach(() => {
+      document.body.innerHTML = '<div>foo\n  <pre>bar\n  baz</pre></div>';
+      element = document.querySelector('div');
+    });
+
+    test('succeeds for correct content', () => {
+      assert.dom(element).includesText('foo\n  bar\n  baz');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar baz',
+        expected: 'foo\n  bar\n  baz',
+        message: 'Element div has text containing "foo\n  bar\n  baz"',
+        result: true,
+      }]);
+    });
+
+    test('succeeds for correct partial content', () => {
+      assert.dom(element).includesText('bar\n  baz');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar baz',
+        expected: 'bar\n  baz',
+        message: 'Element div has text containing "bar\n  baz"',
+        result: true,
+      }]);
+    });
+
+    test('explains failures to the user', () => {
+      assert.dom(element).includesText('bar\n  baz');
+
+      expect(assert.results).toEqual([{
+        actual: 'foo bar baz',
+        expected: 'bar\n  baz',
+        message: 'Element div has text containing "bar\n  baz" -- Your expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.',
+        result: false,
+      }]);
+    });
+  });
+
   describe('with selector', () => {
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -138,7 +138,7 @@ describe('assert.dom(...).includesText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo bar baz',
         expected: 'bar\n  baz',
-        message: 'Element div has text containing "bar\n  baz"\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.',
+        message: 'Element div has text containing "bar\n  baz"\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegExp pattern.',
         result: false,
       }]);
     });

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -122,25 +122,14 @@ describe('assert.dom(...).includesText()', () => {
         result: false,
       }]);
     });
-  });
 
-  describe('with HTMLElement with expected spacing', () => {
-    let element;
+    test('explains failures to the user via `console.warn` if expected text contains collapsable whitespace', () => {
+      const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
 
-    beforeEach(() => {
-      document.body.innerHTML = '<div>foo\n  <pre>bar\n  baz</pre></div>';
-      element = document.querySelector('div');
-    });
+      assert.dom(element).includesText('foo\n  bar');
 
-    test('explains failures to the user', () => {
-      assert.dom(element).includesText('bar\n  baz');
-
-      expect(assert.results).toEqual([{
-        actual: 'foo bar baz',
-        expected: 'bar\n  baz',
-        message: 'Element div has text containing "bar\n  baz"\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegExp pattern.',
-        result: false,
-      }]);
+      expect(warnSpy.mock.calls[0][0]).toMatch('whitespace');
+      warnSpy.mockRestore();
     });
   });
 

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -138,7 +138,7 @@ describe('assert.dom(...).includesText()', () => {
       expect(assert.results).toEqual([{
         actual: 'foo bar baz',
         expected: 'bar\n  baz',
-        message: 'Element div has text containing "bar\n  baz" -- Your expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.',
+        message: 'Element div has text containing "bar\n  baz"\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.',
         result: false,
       }]);
     });

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -132,28 +132,6 @@ describe('assert.dom(...).includesText()', () => {
       element = document.querySelector('div');
     });
 
-    test('succeeds for correct content', () => {
-      assert.dom(element).includesText('foo\n  bar\n  baz');
-
-      expect(assert.results).toEqual([{
-        actual: 'foo bar baz',
-        expected: 'foo\n  bar\n  baz',
-        message: 'Element div has text containing "foo\n  bar\n  baz"',
-        result: true,
-      }]);
-    });
-
-    test('succeeds for correct partial content', () => {
-      assert.dom(element).includesText('bar\n  baz');
-
-      expect(assert.results).toEqual([{
-        actual: 'foo bar baz',
-        expected: 'bar\n  baz',
-        message: 'Element div has text containing "bar\n  baz"',
-        result: true,
-      }]);
-    });
-
     test('explains failures to the user', () => {
       assert.dom(element).includesText('bar\n  baz');
 

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -542,6 +542,10 @@ export default class DOMAssertions {
       message = `Element ${this.targetDescription} has text containing "${text}"`;
     }
 
+    if (!result && text !== collapseWhitespace(text)) {
+      message = `${message} -- Your expected text contains spacing that is not preserved in this assertion. Try the \`.hasText()\` assertion passing in your expected text as a RegEx pattern.`;
+    }
+
     this.pushResult({ result, actual, expected, message });
   }
 

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -543,7 +543,7 @@ export default class DOMAssertions {
     }
 
     if (!result && text !== collapseWhitespace(text)) {
-      message = `${message} -- Your expected text contains spacing that is not preserved in this assertion. Try the \`.hasText()\` assertion passing in your expected text as a RegEx pattern.`;
+      message = message + '\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.';
     }
 
     this.pushResult({ result, actual, expected, message });

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -548,7 +548,7 @@ export default class DOMAssertions {
     }
 
     if (!result && text !== collapseWhitespace(text)) {
-      message = message + '\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegEx pattern.';
+      message = message + '\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegExp pattern.';
     }
 
     this.pushResult({ result, actual, expected, message });

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -438,6 +438,10 @@ export default class DOMAssertions {
    *
    * `expected` can also be a regular expression.
    *
+   * > Note: This assertion will collapse whitespace if the type you pass in is a string.
+   * > If you are testing specifically for whitespace integrity, pass your expected text
+   * > in as a RegEx pattern.
+   *
    * **Aliases:** `matchesText`
    *
    * @param {string|RegExp} expected

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -519,6 +519,11 @@ export default class DOMAssertions {
    * [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent)
    * attribute.
    *
+   * > Note: This assertion will collapse whitespace in `textContent` before searching.
+   * > If you would like to assert on a string that *should* contain line breaks, tabs,
+   * > more than one space in a row, or starting/ending whitespace, use the {@link #hasText}
+   * > selector and pass your expected text in as a RegEx pattern.
+   * 
    * **Aliases:** `containsText`, `hasTextContaining`
    *
    * @param {string} text

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -548,7 +548,7 @@ export default class DOMAssertions {
     }
 
     if (!result && text !== collapseWhitespace(text)) {
-      message = message + '\n\nYour expected text contains spacing that is not preserved in this assertion. Try the `.hasText()` assertion passing in your expected text as a RegExp pattern.';
+      console.warn('The `.includesText()`, `.containsText()`, and `.hasTextContaining()` assertions collapse whitespace. The text you are checking for contains whitespace that may have made your test fail incorrectly. Try the `.hasText()` assertion passing in your expected text as a RegExp pattern. Your text:\n' + text);
     }
 
     this.pushResult({ result, actual, expected, message });


### PR DESCRIPTION
I added three tests. The first two may not be desirable specifications, since passing them might cause a major version bump again. (They test that text containing expected line breaks, etc, would pass.)

The third test is an example of a possible scenario to mitigate confusion described in #197. That would be my suggestion if passing the first two is too much of a burden. Or something like that.