### PR TITLE
Docs: Add missing Markdown links for [ShorthandLinkStyle][]

### DIFF
--- a/API.md
+++ b/API.md
@@ -538,3 +538,6 @@ Assert that the `value` property of an [HTMLInputElement][] is empty.
 ```javascript
 assert.dom('input.username').hasNoValue();
 ```
+
+[HTMLElement]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+[HTMLInputElement]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/documentation.links.js
+++ b/documentation.links.js
@@ -1,0 +1,16 @@
+/* eslint-env node */
+const fs = require('fs');
+
+// Allows documentation to contain simple shorthand links.
+// For example: HTMLElement is defined below, so it will be added to the
+// bottom of the API.md file. As such, all links in documentation that
+// look like `[HTMLElement][]` will be properly resolved.
+
+const links = {
+  HTMLElement: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element',
+  HTMLInputElement: 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input',
+};
+
+const linksMarkdown = '\n' + Object.keys(links).map(key => `[${key}]: ${links[key]}\n`).join('');
+
+fs.appendFileSync('API.md', linksMarkdown);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "rollup -c",
     "changelog": "lerna-changelog",
-    "docs": "yarn build && documentation build dist/qunit-dom.js --config documentation.yml -f md -o API.md",
+    "docs": "yarn build && documentation build dist/qunit-dom.js --config documentation.yml -f md -o API.md && node documentation.links.js",
     "prepublish": "rollup -c",
     "test": "jest",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
There are links missing in the current documentation that are formatted
like `[HTMLElement][]`.

I originally tried to add them by just appending
the corresponding markdown to the `documentation.yml` file.
Unfortunately, when built, the link keys were all `.toLowerCase()`ed.
So I have added a very simple node script to append all necessary
links to the `API.md` file.

This script has been added to the `yarn docs` command, so
introduces no new dependencies.