### PR TITLE
Fix visibility check

### DIFF
--- a/lib/helpers/visible.ts
+++ b/lib/helpers/visible.ts
@@ -3,13 +3,13 @@
 
 export default function visible(el) {
   if (el === null) return false;
-  if (el.offsetWidth === 0 || el.offsetHeight === 0) return false;
+  if (el.offsetWidth === 0 && el.offsetHeight === 0) return false;
 
   let clientRects = el.getClientRects();
   if (clientRects.length === 0) return false;
   for (let i = 0; i < clientRects.length; i++) {
     let rect = clientRects[i];
-    if (rect.width !== 0 && rect.height !== 0) return true;
+    if (rect.width !== 0 || rect.height !== 0) return true;
   }
 
   return false;


### PR DESCRIPTION
Ideally an element is not visible when both its offsetHeight and offsetWidth is 0. You could have elements that have a width but not height.
The [docs](https://github.com/simplabs/qunit-dom/blob/master/API.md#isvisible) say `and` but we check for `or`.

cc: @Turbo87 