### PR TITLE
helpers/node-list: Add missing `@private` declaration

### DIFF
--- a/lib/helpers/node-list.ts
+++ b/lib/helpers/node-list.ts
@@ -6,6 +6,8 @@ export function toArray(list: NodeList): Node[];
 /**
  * This function can be used to convert a NodeList to a regular array.
  * We should be using `Array.from()` for this, but IE11 doesn't support that :(
+ *
+ * @private
  */
 export function toArray(list: NodeList): Node[] {
   return Array.prototype.slice.call(list);


### PR DESCRIPTION
This helper function should not appear in the API docs