### PR TITLE
Specify options.count in exists and isVisible

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,6 +115,7 @@ Assert an [HTMLElement][88] (or multiple) matching the `selector` exists.
 #### Parameters
 
 -   `options` **[object][89]?** 
+-   `options.count` **[number]?**
 -   `message` **[string][90]?** 
 
 #### Examples
@@ -260,6 +261,7 @@ but not necessarily in the viewport.
 #### Parameters
 
 -   `options` **[object][89]?** 
+-  `options.count` **[number]?**
 -   `message` **[string][90]?** 
 
 #### Examples


### PR DESCRIPTION
So it's more clear, in `exists` and `isVisible`, what properties are available in the options object.