### PR TITLE
Remove caret constraint from `prettier` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "jest": "^24.8.0",
     "lerna-changelog": "^0.8.0",
     "loader.js": "^4.2.3",
-    "prettier": "^1.17.1",
+    "prettier": "1.17.1",
     "rollup": "^1.14.2",
     "rollup-plugin-typescript2": "^0.21.1",
     "ts-jest": "^24.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9113,7 +9113,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.17.1:
+prettier@1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.1.tgz#ed64b4e93e370cb8a25b9ef7fef3e4fd1c0995db"
   integrity sha512-TzGRNvuUSmPgwivDqkZ9tM/qTGW9hqDKWOE9YHiyQdixlKbv7kvEqsmDPrcHJTKwthU774TQwZXVtaQ/mMsvjg==


### PR DESCRIPTION
We always want to lock this dependency to specific versions as recommended by their documentation.

This should fix our currently broken CI.