### PR TITLE
Drop support for Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-eslint-parser": "^22.0.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Node 6 has reached the end of it's official support life and will no longer be supported by qunit-dom either.

This unblocks a few dependency updates, e.g. https://github.com/simplabs/qunit-dom/pull/371