### PR TITLE
Adds regex support for CSS class assertions

### DIFF
--- a/API.md
+++ b/API.md
@@ -376,15 +376,22 @@ assert.dom('.foo').isNotDisabled();
 Assert that the [HTMLElement][88] has the `expected` CSS class using
 [`classList`][106].
 
+`expected` can also be a regular expression, and the assertion will return
+true if any of the element's CSS classes match.
+
 #### Parameters
 
--   `expected` **[string][91]** 
+-   `expected` **([string][91] \| [RegExp][101])** 
 -   `message` **[string][91]?** 
 
 #### Examples
 
 ```javascript
 assert.dom('input[type="password"]').hasClass('secret-password-input');
+```
+
+```javascript
+assert.dom('input[type="password"]').hasClass(/.*password-input/);
 ```
 
 ### doesNotHaveClass
@@ -394,17 +401,24 @@ assert.dom('input[type="password"]').hasClass('secret-password-input');
 Assert that the [HTMLElement][88] does not have the `expected` CSS class using
 [`classList`][106].
 
+`expected` can also be a regular expression, and the assertion will return
+true if none of the element's CSS classes match.
+
 **Aliases:** `hasNoClass`, `lacksClass`
 
 #### Parameters
 
--   `expected` **[string][91]** 
+-   `expected` **([string][91] \| [RegExp][101])** 
 -   `message` **[string][91]?** 
 
 #### Examples
 
 ```javascript
 assert.dom('input[type="password"]').doesNotHaveClass('username-input');
+```
+
+```javascript
+assert.dom('input[type="password"]').doesNotHaveClass(/username-.*-input/);
 ```
 
 ### hasText

--- a/lib/__tests__/does-not-have-class.ts
+++ b/lib/__tests__/does-not-have-class.ts
@@ -11,48 +11,50 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
     document.body.innerHTML = '<input type="password" class="secret-password-input foo">';
   });
 
-  test('succeeds for correct content', () => {
-    assert.dom('input[type="password"]').doesNotHaveClass('username-input');
-    assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass('username-input');
+  describe('string expected', () => {
+    test('succeeds for correct content', () => {
+      assert.dom('input[type="password"]').doesNotHaveClass('username-input');
+      assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass('username-input');
 
-    expect(assert.results).toEqual([
-      {
-        actual: 'secret-password-input foo',
-        expected: 'not: username-input',
-        message: 'Element input[type="password"] does not have CSS class "username-input"',
-        result: true,
-      },
-      {
-        actual: 'secret-password-input foo',
-        expected: 'not: username-input',
-        message:
-          'Element input.secret-password-input.foo[type="password"] does not have CSS class "username-input"',
-        result: true,
-      },
-    ]);
-  });
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: username-input',
+          message: 'Element input[type="password"] does not have CSS class "username-input"',
+          result: true,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: username-input',
+          message:
+            'Element input.secret-password-input.foo[type="password"] does not have CSS class "username-input"',
+          result: true,
+        },
+      ]);
+    });
 
-  test('fails for wrong content', () => {
-    assert.dom('input[type="password"]').doesNotHaveClass('secret-password-input');
-    assert
-      .dom(document.querySelector('input[type="password"]'))
-      .doesNotHaveClass('secret-password-input');
+    test('fails for wrong content', () => {
+      assert.dom('input[type="password"]').doesNotHaveClass('secret-password-input');
+      assert
+        .dom(document.querySelector('input[type="password"]'))
+        .doesNotHaveClass('secret-password-input');
 
-    expect(assert.results).toEqual([
-      {
-        actual: 'secret-password-input foo',
-        expected: 'not: secret-password-input',
-        message: 'Element input[type="password"] does not have CSS class "secret-password-input"',
-        result: false,
-      },
-      {
-        actual: 'secret-password-input foo',
-        expected: 'not: secret-password-input',
-        message:
-          'Element input.secret-password-input.foo[type="password"] does not have CSS class "secret-password-input"',
-        result: false,
-      },
-    ]);
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: secret-password-input',
+          message: 'Element input[type="password"] does not have CSS class "secret-password-input"',
+          result: false,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: secret-password-input',
+          message:
+            'Element input.secret-password-input.foo[type="password"] does not have CSS class "secret-password-input"',
+          result: false,
+        },
+      ]);
+    });
   });
 
   test('fails for missing element', () => {

--- a/lib/__tests__/does-not-have-class.ts
+++ b/lib/__tests__/does-not-have-class.ts
@@ -57,6 +57,52 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
     });
   });
 
+  describe('regex expected', () => {
+    test('succeeds for correct content', () => {
+      assert.dom('input[type="password"]').doesNotHaveClass(/public-password.*/);
+      assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass(/public-password.*/);
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: /public-password.*/',
+          message: 'Element input[type="password"] does not have CSS class matching /public-password.*/',
+          result: true,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: /public-password.*/',
+          message:
+            'Element input.secret-password-input.foo[type="password"] does not have CSS class matching /public-password.*/',
+          result: true,
+        },
+      ]);
+    });
+
+    test('fails for wrong content', () => {
+      assert.dom('input[type="password"]').doesNotHaveClass(/.*password/);
+      assert
+        .dom(document.querySelector('input[type="password"]'))
+        .doesNotHaveClass(/.*password/);
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: /.*password/',
+          message: 'Element input[type="password"] does not have CSS class matching /.*password/',
+          result: false,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'not: /.*password/',
+          message:
+            'Element input.secret-password-input.foo[type="password"] does not have CSS class matching /.*password/',
+          result: false,
+        },
+      ]);
+    });
+  });
+
   test('fails for missing element', () => {
     assert.dom('#missing').doesNotHaveClass('foo');
 

--- a/lib/__tests__/does-not-have-class.ts
+++ b/lib/__tests__/does-not-have-class.ts
@@ -14,7 +14,9 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
   describe('string expected', () => {
     test('succeeds for correct content', () => {
       assert.dom('input[type="password"]').doesNotHaveClass('username-input');
-      assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass('username-input');
+      assert
+        .dom(document.querySelector('input[type="password"]'))
+        .doesNotHaveClass('username-input');
 
       expect(assert.results).toEqual([
         {
@@ -60,13 +62,16 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
   describe('regex expected', () => {
     test('succeeds for correct content', () => {
       assert.dom('input[type="password"]').doesNotHaveClass(/public-password.*/);
-      assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass(/public-password.*/);
+      assert
+        .dom(document.querySelector('input[type="password"]'))
+        .doesNotHaveClass(/public-password.*/);
 
       expect(assert.results).toEqual([
         {
           actual: 'secret-password-input foo',
           expected: 'not: /public-password.*/',
-          message: 'Element input[type="password"] does not have CSS class matching /public-password.*/',
+          message:
+            'Element input[type="password"] does not have CSS class matching /public-password.*/',
           result: true,
         },
         {
@@ -81,9 +86,7 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
 
     test('fails for wrong content', () => {
       assert.dom('input[type="password"]').doesNotHaveClass(/.*password/);
-      assert
-        .dom(document.querySelector('input[type="password"]'))
-        .doesNotHaveClass(/.*password/);
+      assert.dom(document.querySelector('input[type="password"]')).doesNotHaveClass(/.*password/);
 
       expect(assert.results).toEqual([
         {

--- a/lib/__tests__/has-class.ts
+++ b/lib/__tests__/has-class.ts
@@ -55,6 +55,50 @@ describe('assert.dom(...).hasClass()', () => {
     });
   });
 
+  describe('regex expected', () => {
+    test('succeeds for correct content', () => {
+      assert.dom('input[type="password"]').hasClass(/.*password/);
+      assert.dom(document.querySelector('input[type="password"]')).hasClass(/.*password/);
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: /.*password/,
+          message: 'Element input[type="password"] has CSS class matching /.*password/',
+          result: true,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: /.*password/,
+          message:
+            'Element input.secret-password-input.foo[type="password"] has CSS class matching /.*password/',
+          result: true,
+        },
+      ]);
+    });
+
+    test('fails for wrong content', () => {
+      assert.dom('input[type="password"]').hasClass(/public-password.*/);
+      assert.dom(document.querySelector('input[type="password"]')).hasClass(/public-password.*/);
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: /public-password.*/,
+          message: 'Element input[type="password"] has CSS class matching /public-password.*/',
+          result: false,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: /public-password.*/,
+          message:
+            'Element input.secret-password-input.foo[type="password"] has CSS class matching /public-password.*/',
+          result: false,
+        },
+      ]);
+    });
+  });
+
   test('fails for missing element', () => {
     assert.dom('#missing').hasClass('foo');
 

--- a/lib/__tests__/has-class.ts
+++ b/lib/__tests__/has-class.ts
@@ -11,46 +11,48 @@ describe('assert.dom(...).hasClass()', () => {
     document.body.innerHTML = '<input type="password" class="secret-password-input foo">';
   });
 
-  test('succeeds for correct content', () => {
-    assert.dom('input[type="password"]').hasClass('secret-password-input');
-    assert.dom(document.querySelector('input[type="password"]')).hasClass('secret-password-input');
+  describe('string expected', () => {
+    test('succeeds for correct content', () => {
+      assert.dom('input[type="password"]').hasClass('secret-password-input');
+      assert.dom(document.querySelector('input[type="password"]')).hasClass('secret-password-input');
 
-    expect(assert.results).toEqual([
-      {
-        actual: 'secret-password-input foo',
-        expected: 'secret-password-input',
-        message: 'Element input[type="password"] has CSS class "secret-password-input"',
-        result: true,
-      },
-      {
-        actual: 'secret-password-input foo',
-        expected: 'secret-password-input',
-        message:
-          'Element input.secret-password-input.foo[type="password"] has CSS class "secret-password-input"',
-        result: true,
-      },
-    ]);
-  });
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'secret-password-input',
+          message: 'Element input[type="password"] has CSS class "secret-password-input"',
+          result: true,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'secret-password-input',
+          message:
+            'Element input.secret-password-input.foo[type="password"] has CSS class "secret-password-input"',
+          result: true,
+        },
+      ]);
+    });
 
-  test('fails for wrong content', () => {
-    assert.dom('input[type="password"]').hasClass('username-input');
-    assert.dom(document.querySelector('input[type="password"]')).hasClass('username-input');
+    test('fails for wrong content', () => {
+      assert.dom('input[type="password"]').hasClass('username-input');
+      assert.dom(document.querySelector('input[type="password"]')).hasClass('username-input');
 
-    expect(assert.results).toEqual([
-      {
-        actual: 'secret-password-input foo',
-        expected: 'username-input',
-        message: 'Element input[type="password"] has CSS class "username-input"',
-        result: false,
-      },
-      {
-        actual: 'secret-password-input foo',
-        expected: 'username-input',
-        message:
-          'Element input.secret-password-input.foo[type="password"] has CSS class "username-input"',
-        result: false,
-      },
-    ]);
+      expect(assert.results).toEqual([
+        {
+          actual: 'secret-password-input foo',
+          expected: 'username-input',
+          message: 'Element input[type="password"] has CSS class "username-input"',
+          result: false,
+        },
+        {
+          actual: 'secret-password-input foo',
+          expected: 'username-input',
+          message:
+            'Element input.secret-password-input.foo[type="password"] has CSS class "username-input"',
+          result: false,
+        },
+      ]);
+    });
   });
 
   test('fails for missing element', () => {

--- a/lib/__tests__/has-class.ts
+++ b/lib/__tests__/has-class.ts
@@ -14,7 +14,9 @@ describe('assert.dom(...).hasClass()', () => {
   describe('string expected', () => {
     test('succeeds for correct content', () => {
       assert.dom('input[type="password"]').hasClass('secret-password-input');
-      assert.dom(document.querySelector('input[type="password"]')).hasClass('secret-password-input');
+      assert
+        .dom(document.querySelector('input[type="password"]'))
+        .hasClass('secret-password-input');
 
       expect(assert.results).toEqual([
         {

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -481,35 +481,55 @@ export default class DOMAssertions {
    * Assert that the {@link HTMLElement} does not have the `expected` CSS class using
    * [`classList`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList).
    *
+   * `expected` can also be a regular expression, and the assertion will return
+   * true if none of the element's CSS classes match.
+   *
    * **Aliases:** `hasNoClass`, `lacksClass`
    *
-   * @param {string} expected
+   * @param {string|RegExp} expected
    * @param {string?} message
    *
    * @example
    * assert.dom('input[type="password"]').doesNotHaveClass('username-input');
    *
+   * @example
+   * assert.dom('input[type="password"]').doesNotHaveClass(/username-.*-input/);
+   *
    * @see {@link #hasClass}
    */
-  doesNotHaveClass(expected: string, message?: string): void {
+  doesNotHaveClass(expected: string | RegExp, message?: string): void {
     let element = this.findTargetElement();
     if (!element) return;
 
-    let result = !element.classList.contains(expected);
     let actual = element.classList.toString();
 
-    if (!message) {
-      message = `Element ${this.targetDescription} does not have CSS class "${expected}"`;
-    }
+    if (expected instanceof RegExp) {
+      let classNames = Array.prototype.slice.call(element.classList)
+      let result = classNames.every((className: string): boolean => {
+        return !expected.test(className);
+      })
 
-    this.pushResult({ result, actual, expected: `not: ${expected}`, message });
+      if (!message) {
+        message = `Element ${this.targetDescription} does not have CSS class matching ${expected}`;
+      }
+
+      this.pushResult({ result, actual, expected: `not: ${expected}`, message });
+    } else {
+      let result = !element.classList.contains(expected);
+
+      if (!message) {
+        message = `Element ${this.targetDescription} does not have CSS class "${expected}"`;
+      }
+
+      this.pushResult({ result, actual, expected: `not: ${expected}`, message });
+    }
   }
 
-  hasNoClass(expected: string, message?: string): void {
+  hasNoClass(expected: string | RegExp, message?: string): void {
     this.doesNotHaveClass(expected, message);
   }
 
-  lacksClass(expected: string, message?: string): void {
+  lacksClass(expected: string | RegExp, message?: string): void {
     this.doesNotHaveClass(expected, message);
   }
 

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -435,26 +435,46 @@ export default class DOMAssertions {
    * Assert that the {@link HTMLElement} has the `expected` CSS class using
    * [`classList`](https://developer.mozilla.org/en-US/docs/Web/API/Element/classList).
    *
-   * @param {string} expected
+   * `expected` can also be a regular expression, and the assertion will return
+   * true if any of the element's CSS classes match.
+   *
+   * @param {string|RegExp} expected
    * @param {string?} message
    *
    * @example
    * assert.dom('input[type="password"]').hasClass('secret-password-input');
    *
+   * @example
+   * assert.dom('input[type="password"]').hasClass(/.*password-input/);
+   *
    * @see {@link #doesNotHaveClass}
    */
-  hasClass(expected: string, message?: string): void {
+  hasClass(expected: string | RegExp, message?: string): void {
     let element = this.findTargetElement();
     if (!element) return;
 
     let actual = element.classList.toString();
-    let result = element.classList.contains(expected);
 
-    if (!message) {
-      message = `Element ${this.targetDescription} has CSS class "${expected}"`;
+    if (expected instanceof RegExp) {
+      let classNames = Array.prototype.slice.call(element.classList)
+      let result = classNames.some((className: string): boolean => {
+        return expected.test(className);
+      })
+
+      if (!message) {
+        message = `Element ${this.targetDescription} has CSS class matching ${expected}`;
+      }
+
+      this.pushResult({ result, actual, expected, message });
+    } else {
+      let result = element.classList.contains(expected);
+
+      if (!message) {
+        message = `Element ${this.targetDescription} has CSS class "${expected}"`;
+      }
+
+      this.pushResult({ result, actual, expected, message });
     }
-
-    this.pushResult({ result, actual, expected, message });
   }
 
   /**

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -456,10 +456,10 @@ export default class DOMAssertions {
     let actual = element.classList.toString();
 
     if (expected instanceof RegExp) {
-      let classNames = Array.prototype.slice.call(element.classList)
+      let classNames = Array.prototype.slice.call(element.classList);
       let result = classNames.some((className: string): boolean => {
         return expected.test(className);
-      })
+      });
 
       if (!message) {
         message = `Element ${this.targetDescription} has CSS class matching ${expected}`;
@@ -504,10 +504,10 @@ export default class DOMAssertions {
     let actual = element.classList.toString();
 
     if (expected instanceof RegExp) {
-      let classNames = Array.prototype.slice.call(element.classList)
+      let classNames = Array.prototype.slice.call(element.classList);
       let result = classNames.every((className: string): boolean => {
         return !expected.test(className);
-      })
+      });
 
       if (!message) {
         message = `Element ${this.targetDescription} does not have CSS class matching ${expected}`;


### PR DESCRIPTION
This PR adds RegExp support to the `hasClass` and `doesNotHaveClass` assertions, as suggested in https://github.com/simplabs/qunit-dom/issues/450. 

Both functions now accept `string|RegExp`, in the same vein as `hasText`.

Each CSS class present on the target element will be matched against the RegExp, and:

- for the positive `hasClass` assertion to return `true`, at least one CSS class must match; and
- for the negative `doesNotHaveClass` assertion to return `true`, none of the CSS classes may match


Resolves #450