### PR TITLE
Use collapseWhitespace when using Regex

### DIFF
--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -584,8 +584,8 @@ export default class DOMAssertions {
     if (!element) return;
 
     if (expected instanceof RegExp) {
-      let result = expected.test(element.textContent);
-      let actual = element.textContent;
+      let actual = collapseWhitespace(element.textContent);
+      let result = expected.test(actual);
 
       if (!message) {
         message = `Element ${this.targetDescription} has text matching ${expected}`;


### PR DESCRIPTION
This seems like an inconsistency, and threw me off trying to test with a regex. This should collapse space for both regex and string now.