### PR TITLE
task(bug): Fixes tests to correctly ignore dist output

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
     }
   },
   "jest": {
-    "preset": "ts-jest"
+    "preset": "ts-jest",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/dist/"
+    ]
   }
 }


### PR DESCRIPTION
It appears the build is failing due to `jest` running `.d.ts` files within `dist/__tests__`. This PR adds an ignore to that directory.