### PR TITLE
TypeScript: Turn on `noImplicityAny` and fix a few type signatures

### DIFF
--- a/lib/__tests__/does-not-exist.ts
+++ b/lib/__tests__/does-not-exist.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotExist()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -76,10 +76,14 @@ describe('assert.dom(...).doesNotExist()', () => {
       'Unexpected Parameter: [object HTMLBodyElement]'
     );
 
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotExist()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotExist()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).doesNotExist()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotExist()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotExist()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/does-not-have-attribute.ts
+++ b/lib/__tests__/does-not-have-attribute.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotHaveAttribute()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -84,16 +84,20 @@ describe('assert.dom(...).doesNotHaveAttribute()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveAttribute('disabled')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotHaveAttribute('disabled')).toThrow(
       'Unexpected Parameter: true'
     );
     expect(() => assert.dom(undefined).doesNotHaveAttribute('disabled')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotHaveAttribute('disabled')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotHaveAttribute('disabled')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/does-not-have-class.ts
+++ b/lib/__tests__/does-not-have-class.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotHaveClass()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -118,14 +118,18 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveClass('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotHaveClass('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).doesNotHaveClass('foo')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotHaveClass('foo')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotHaveClass('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/does-not-have-style.ts
+++ b/lib/__tests__/does-not-have-style.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotHaveStyle()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -91,16 +91,20 @@ describe('assert.dom(...).doesNotHaveStyle()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveStyle({ opacity: 1 })).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotHaveStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: true'
     );
     expect(() => assert.dom(undefined).doesNotHaveStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotHaveStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotHaveStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/does-not-have-tagname.ts
+++ b/lib/__tests__/does-not-have-tagname.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotHaveTagName()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).doesNotHaveTagName()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<section id="block">Section</section>\n';
@@ -114,21 +114,25 @@ describe('assert.dom(...).doesNotHaveTagName()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveTagName('div')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotHaveTagName('div')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).doesNotHaveTagName('div')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotHaveTagName('div')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotHaveTagName('div')).toThrow(
       'Unexpected Parameter: [object Document]'
     );
   });
 
   describe('invalid arguments to `doesNotHaveTagName`', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<section id="block">Section</section>\n';
@@ -136,12 +140,14 @@ describe('assert.dom(...).doesNotHaveTagName()', () => {
     });
 
     test('passing a number to `doesNotHaveTagName` will throw an error', () => {
+      //@ts-ignore
       expect(() => assert.dom(element).doesNotHaveTagName(1234)).toThrow(
         'You must pass a string to "doesNotHaveTagName". You passed 1234'
       );
     });
 
     test('passing an object to `doesNotHaveTagName` will throw an error', () => {
+      //@ts-ignore
       expect(() => assert.dom(element).doesNotHaveTagName({})).toThrow(
         'You must pass a string to "doesNotHaveTagName". You passed [object Object]'
       );

--- a/lib/__tests__/does-not-include-text.ts
+++ b/lib/__tests__/does-not-include-text.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotIncludeText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
@@ -114,14 +114,18 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).doesNotIncludeText('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).doesNotIncludeText('foo')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).doesNotIncludeText('foo')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).doesNotIncludeText('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/does-not-match-selector.ts
+++ b/lib/__tests__/does-not-match-selector.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).doesNotMatchSelector()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();

--- a/lib/__tests__/exists.ts
+++ b/lib/__tests__/exists.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).exists()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -140,10 +140,14 @@ describe('assert.dom(...).exists()', () => {
       'Unexpected Parameter: [object HTMLBodyElement]'
     );
 
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).exists()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).exists()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).exists()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).exists()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).exists()).toThrow('Unexpected Parameter: [object Document]');
   });
 });

--- a/lib/__tests__/has-any-text.ts
+++ b/lib/__tests__/has-any-text.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasAnyText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -65,10 +65,14 @@ describe('assert.dom(...).hasAnyText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAnyText()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasAnyText()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasAnyText()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasAnyText()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasAnyText()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-any-value.ts
+++ b/lib/__tests__/has-any-value.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasAnyValue()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -66,10 +66,15 @@ describe('assert.dom(...).hasAnyValue()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAnyValue()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasAnyValue()).toThrow('Unexpected Parameter: true');
+    //@ts-ignore
     expect(() => assert.dom(undefined).hasAnyValue()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasAnyValue()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasAnyValue()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-attribute.ts
+++ b/lib/__tests__/has-attribute.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasAttribute()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -239,14 +239,18 @@ describe('assert.dom(...).hasAttribute()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAttribute('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasAttribute('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasAttribute('foo')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).hasAttribute('foo')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).hasAttribute('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-class.ts
+++ b/lib/__tests__/has-class.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasClass()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -113,10 +113,14 @@ describe('assert.dom(...).hasClass()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasClass('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasClass('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasClass('foo')).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasClass('foo')).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasClass('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-no-text.ts
+++ b/lib/__tests__/has-no-text.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasNoText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -63,10 +63,14 @@ describe('assert.dom(...).hasNoText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasNoText()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasNoText()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasNoText()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasNoText()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasNoText()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-no-value.ts
+++ b/lib/__tests__/has-no-value.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasNoValue()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -65,10 +65,14 @@ describe('assert.dom(...).hasNoValue()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasNoValue()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasNoValue()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasNoValue()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasNoValue()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasNoValue()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-pseudo-element-style.ts
+++ b/lib/__tests__/has-pseudo-element-style.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasPseudoElementStyle()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();

--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasStyle()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -90,14 +90,18 @@ describe('assert.dom(...).hasStyle()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).hasStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).hasStyle({ opacity: 1 })).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-tagname.ts
+++ b/lib/__tests__/has-tagname.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasTagName()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).hasTagName()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 id="title">Title</h1>\n';
@@ -114,17 +114,21 @@ describe('assert.dom(...).hasTagName()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasTagName('h1')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasTagName('h1')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasTagName('h1')).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasTagName('h1')).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasTagName('h1')).toThrow(
       'Unexpected Parameter: [object Document]'
     );
   });
 
   describe('invalid arguments to `hasTagName`', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 id="title">Title</h1>\n';
@@ -132,12 +136,14 @@ describe('assert.dom(...).hasTagName()', () => {
     });
 
     test('passing a number to `hasTagName` will throw an error', () => {
+      //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
       expect(() => assert.dom(element).hasTagName(1234)).toThrow(
         'You must pass a string to "hasTagName". You passed 1234'
       );
     });
 
     test('passing an object to `hasTagName` will throw an error', () => {
+      //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
       expect(() => assert.dom(element).hasTagName({})).toThrow(
         'You must pass a string to "hasTagName". You passed [object Object]'
       );

--- a/lib/__tests__/has-text-regex.ts
+++ b/lib/__tests__/has-text-regex.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).hasText()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
@@ -140,10 +140,14 @@ describe('assert.dom(...).hasText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasText(/fo+/)).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasText(/fo+/)).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasText(/fo+/)).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasText(/fo+/)).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasText(/fo+/)).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/has-text.ts
+++ b/lib/__tests__/has-text.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).hasText()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h2 id="title">\n\tWelcome to <b>QUnit</b>\n</h2>\n';
@@ -114,17 +114,21 @@ describe('assert.dom(...).hasText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasText('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasText('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasText('foo')).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasText('foo')).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasText('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );
   });
 
   describe('invalid arguments to `hasText`', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h2 id="title">\n\tWelcome to <b>QUnit</b>\n</h2>\n';
@@ -132,12 +136,14 @@ describe('assert.dom(...).hasText()', () => {
     });
 
     test('passing a number to `hasText` will throw an error', () => {
+      //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
       expect(() => assert.dom(element).hasText(1234)).toThrow(
         'You must pass a string or Regular Expression to "hasText". You passed 1234'
       );
     });
 
     test('passing an object to `hasText` will throw an error', () => {
+      //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
       expect(() => assert.dom(element).hasText({})).toThrow(
         'You must pass a string or Regular Expression to "hasText". You passed [object Object]'
       );

--- a/lib/__tests__/has-value.ts
+++ b/lib/__tests__/has-value.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).hasValue()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -222,10 +222,14 @@ describe('assert.dom(...).hasValue()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasValue('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).hasValue('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).hasValue('foo')).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).hasValue('foo')).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).hasValue('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).includesText()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).includesText()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
@@ -84,7 +84,7 @@ describe('assert.dom(...).includesText()', () => {
   });
 
   describe('with HTMLElement with irregular-spacing', () => {
-    let element;
+    let element: Element;
 
     beforeEach(() => {
       document.body.innerHTML = '<h1 class="baz">foo\n  <span>bar</span>\n</h1>baz';
@@ -208,14 +208,18 @@ describe('assert.dom(...).includesText()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).includesText('foo')).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).includesText('foo')).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).includesText('foo')).toThrow(
       'Unexpected Parameter: undefined'
     );
+    //@ts-ignore
     expect(() => assert.dom({}).includesText('foo')).toThrow(
       'Unexpected Parameter: [object Object]'
     );
+    //@ts-ignore
     expect(() => assert.dom(document).includesText('foo')).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-checked.ts
+++ b/lib/__tests__/is-checked.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isChecked()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isChecked()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="checkbox" checked>';
@@ -176,10 +176,14 @@ describe('assert.dom(...).isChecked()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isChecked()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isChecked()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isChecked()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isChecked()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isChecked()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-disabled.ts
+++ b/lib/__tests__/is-disabled.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isDisabled()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isDisabled()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="text" disabled>';
@@ -146,10 +146,14 @@ describe('assert.dom(...).isDisabled()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isDisabled()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isDisabled()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isDisabled()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isDisabled()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isDisabled()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-focused.ts
+++ b/lib/__tests__/is-focused.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isFocused()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isFocused()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = 'foo<input type="email">bar';
@@ -122,10 +122,14 @@ describe('assert.dom(...).isFocused()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isFocused()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isFocused()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isFocused()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isFocused()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isFocused()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-not-checked.ts
+++ b/lib/__tests__/is-not-checked.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isNotChecked()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isNotChecked()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="checkbox">';
@@ -176,10 +176,14 @@ describe('assert.dom(...).isNotChecked()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isNotChecked()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isNotChecked()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isNotChecked()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isNotChecked()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isNotChecked()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-not-disabled.ts
+++ b/lib/__tests__/is-not-disabled.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isNotDisabled()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isNotDisabled()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="text">';
@@ -146,10 +146,14 @@ describe('assert.dom(...).isNotDisabled()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isNotDisabled()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isNotDisabled()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isNotDisabled()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isNotDisabled()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isNotDisabled()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-not-focused.ts
+++ b/lib/__tests__/is-not-focused.ts
@@ -18,6 +18,8 @@ describe('assert.dom(...).isNotFocused()', () => {
       {
         message: 'foo',
         result: true,
+        actual: 'Element h1 is not focused',
+        expected: 'Element h1 is not focused',
       },
     ]);
   });
@@ -39,6 +41,8 @@ describe('assert.dom(...).isNotFocused()', () => {
         {
           message: 'Element input[type="email"] is not focused',
           result: true,
+          actual: 'Element input[type="email"] is not focused',
+          expected: 'Element input[type="email"] is not focused',
         },
       ]);
     });
@@ -52,6 +56,8 @@ describe('assert.dom(...).isNotFocused()', () => {
         {
           message: 'Element input[type="email"] is not focused',
           result: false,
+          actual: 'Element input[type="email"] is focused',
+          expected: 'Element input[type="email"] is not focused',
         },
       ]);
     });
@@ -82,6 +88,8 @@ describe('assert.dom(...).isNotFocused()', () => {
         {
           message: 'Element input is not focused',
           result: true,
+          actual: 'Element input is not focused',
+          expected: 'Element input is not focused',
         },
       ]);
     });
@@ -95,6 +103,8 @@ describe('assert.dom(...).isNotFocused()', () => {
         {
           message: 'Element input is not focused',
           result: false,
+          actual: 'Element input is focused',
+          expected: 'Element input is not focused',
         },
       ]);
     });

--- a/lib/__tests__/is-not-focused.ts
+++ b/lib/__tests__/is-not-focused.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isNotFocused()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -23,7 +23,7 @@ describe('assert.dom(...).isNotFocused()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = 'foo<input type="email">bar';
@@ -112,10 +112,14 @@ describe('assert.dom(...).isNotFocused()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isNotFocused()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isNotFocused()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isNotFocused()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isNotFocused()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isNotFocused()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-not-required.ts
+++ b/lib/__tests__/is-not-required.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isNotRequired()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isNotRequired()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="text">';
@@ -116,10 +116,14 @@ describe('assert.dom(...).isNotRequired()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isNotRequired()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isNotRequired()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isNotRequired()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isNotRequired()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isNotRequired()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-not-visible.ts
+++ b/lib/__tests__/is-not-visible.ts
@@ -11,7 +11,7 @@ import TestAssertions from '../helpers/test-assertions';
  * Tests for the success cases of isNotVisible can be found in tests/acceptance/qunit-dom-test.js
  */
 describe('assert.dom(...).isNotVisible()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -52,10 +52,14 @@ describe('assert.dom(...).isNotVisible()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isNotVisible()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isNotVisible()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isNotVisible()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isNotVisible()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isNotVisible()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-required.ts
+++ b/lib/__tests__/is-required.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isRequired()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -25,7 +25,7 @@ describe('assert.dom(...).isRequired()', () => {
   });
 
   describe('with HTMLElement', () => {
-    let element;
+    let element: HTMLInputElement;
 
     beforeEach(() => {
       document.body.innerHTML = '<input type="text" required>';
@@ -116,10 +116,14 @@ describe('assert.dom(...).isRequired()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isRequired()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isRequired()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isRequired()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isRequired()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
     expect(() => assert.dom(document).isRequired()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/is-visible.ts
+++ b/lib/__tests__/is-visible.ts
@@ -11,7 +11,7 @@ import TestAssertions from '../helpers/test-assertions';
  * Additional tests cases of isVisible can be found in tests/acceptance/qunit-dom-test.js
  */
 describe('assert.dom(...).isVisible()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();
@@ -69,10 +69,14 @@ describe('assert.dom(...).isVisible()', () => {
   });
 
   test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).isVisible()).toThrow('Unexpected Parameter: 5');
+    //@ts-ignore
     expect(() => assert.dom(true).isVisible()).toThrow('Unexpected Parameter: true');
     expect(() => assert.dom(undefined).isVisible()).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
     expect(() => assert.dom({}).isVisible()).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignores
     expect(() => assert.dom(document).isVisible()).toThrow(
       'Unexpected Parameter: [object Document]'
     );

--- a/lib/__tests__/matches-selector.ts
+++ b/lib/__tests__/matches-selector.ts
@@ -3,7 +3,7 @@
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).matchesSelector()', () => {
-  let assert;
+  let assert: TestAssertions;
 
   beforeEach(() => {
     assert = new TestAssertions();

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -23,6 +23,10 @@ export interface ExistsOptions {
   count: number;
 }
 
+export interface Dictionary<T> {
+  [key: string]: T;
+}
+
 export default class DOMAssertions {
   constructor(
     private target: string | Element | null,
@@ -588,7 +592,7 @@ export default class DOMAssertions {
    */
   hasPseudoElementStyle(
     selector: string | null,
-    expected: { [key: string]: any },
+    expected: Dictionary<string>,
     message?: string
   ): void {
     let element = this.findTargetElement();
@@ -599,7 +603,7 @@ export default class DOMAssertions {
     let result = expectedProperties.every(
       property => computedStyle[property] === expected[property]
     );
-    let actual: { [key: string]: any } = {};
+    let actual: Dictionary<string> = {};
 
     expectedProperties.forEach(property => (actual[property] = computedStyle[property]));
 

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -12,10 +12,21 @@ import elementToString from './helpers/element-to-string';
 import collapseWhitespace from './helpers/collapse-whitespace';
 import { toArray } from './helpers/node-list';
 
+export interface AssertionResult {
+  result: boolean;
+  actual: any;
+  expected: any;
+  message: string;
+}
+
+export interface ExistsOptions {
+  count: number;
+}
+
 export default class DOMAssertions {
   constructor(
     private target: string | Element | null,
-    private rootElement: Element,
+    private rootElement: Element | Document,
     private testContext: Assert
   ) {}
 
@@ -43,7 +54,7 @@ export default class DOMAssertions {
    *
    * @see {@link #doesNotExist}
    */
-  exists(options: { count: number }, message?: string): void;
+  exists(options: ExistsOptions, message?: string): void;
 
   /**
    * Assert an {@link HTMLElement} (or multiple) matching the `selector` exists.
@@ -58,7 +69,7 @@ export default class DOMAssertions {
    *
    * @see {@link #doesNotExist}
    */
-  exists(options: { count: number } | string, message?: string): void {
+  exists(options: ExistsOptions | string, message?: string): void {
     exists.call(this, options, message);
   }
 
@@ -212,7 +223,7 @@ export default class DOMAssertions {
    *
    * @see {@link #isNotVisible}
    */
-  isVisible(options: { count: number }, message?: string): void;
+  isVisible(options: ExistsOptions, message?: string): void;
 
   /**
    * Assert that the {@link HTMLElement} or an {@link HTMLElement} matching the
@@ -236,7 +247,7 @@ export default class DOMAssertions {
    *
    * @see {@link #isNotVisible}
    */
-  isVisible(options: { count: number } | string, message?: string): void {
+  isVisible(options: ExistsOptions | string, message?: string): void {
     isVisible.call(this, options, message);
   }
 
@@ -575,16 +586,20 @@ export default class DOMAssertions {
    *
    * @see {@link #hasClass}
    */
-  hasPseudoElementStyle(selector: string | null, expected: object, message?: string): void {
+  hasPseudoElementStyle(
+    selector: string | null,
+    expected: { [key: string]: any },
+    message?: string
+  ): void {
     let element = this.findTargetElement();
     if (!element) return;
 
     let computedStyle = window.getComputedStyle(element, selector);
-    let expectedProperties = Object.keys(expected);
+    let expectedProperties = Object.keys(expected) as [keyof CSSStyleDeclaration];
     let result = expectedProperties.every(
       property => computedStyle[property] === expected[property]
     );
-    let actual = {};
+    let actual: { [key: string]: any } = {};
 
     expectedProperties.forEach(property => (actual[property] = computedStyle[property]));
 
@@ -636,16 +651,21 @@ export default class DOMAssertions {
    *
    * @see {@link #hasClass}
    */
-  doesNotHavePseudoElementStyle(selector: string | null, expected: object, message: string) {
+  doesNotHavePseudoElementStyle(
+    selector: string | null,
+    expected: { [key: string]: any },
+    message: string
+  ): void {
     let element = this.findTargetElement();
     if (!element) return;
 
     let computedStyle = window.getComputedStyle(element, selector);
-    let expectedProperties = Object.keys(expected);
+
+    let expectedProperties = Object.keys(expected) as [keyof CSSStyleDeclaration];
     let result = expectedProperties.some(
       property => computedStyle[property] !== expected[property]
     );
-    let actual = {};
+    let actual: { [key: string]: any } = {};
 
     expectedProperties.forEach(property => (actual[property] = computedStyle[property]));
 
@@ -871,7 +891,7 @@ export default class DOMAssertions {
    * @see {@link #hasAnyValue}
    * @see {@link #hasNoValue}
    */
-  hasValue(expected: string | RegExp | { any: true }, message?: string) {
+  hasValue(expected?: string | RegExp | { any: true }, message?: string): void {
     let element = this.findTargetElement();
     if (!element) return;
 
@@ -959,7 +979,7 @@ export default class DOMAssertions {
    * @example
    * assert.dom('p.red').matchesSelector('div.wrapper p:last-child')
    */
-  matchesSelector(compareSelector: string, message?: string) {
+  matchesSelector(compareSelector: string, message?: string): void {
     let targetElements = this.target instanceof Element ? [this.target] : this.findElements();
     let targets = targetElements.length;
     let matchFailures = matchesSelector(targetElements, compareSelector);
@@ -1003,7 +1023,7 @@ export default class DOMAssertions {
    * @example
    * assert.dom('input').doesNotMatchSelector('input[disabled]')
    */
-  doesNotMatchSelector(compareSelector: string, message?: string) {
+  doesNotMatchSelector(compareSelector: string, message?: string): void {
     let targetElements = this.target instanceof Element ? [this.target] : this.findElements();
     let targets = targetElements.length;
     let matchFailures = matchesSelector(targetElements, compareSelector);
@@ -1054,7 +1074,7 @@ export default class DOMAssertions {
    *
    * assert.dom('#title').hasTagName('h1');
    */
-  hasTagName(tagName: string, message?: string) {
+  hasTagName(tagName: string, message?: string): void {
     let element = this.findTargetElement();
     let actual;
     let expected;
@@ -1099,7 +1119,7 @@ export default class DOMAssertions {
    *
    * assert.dom('section#block').doesNotHaveTagName('div');
    */
-  doesNotHaveTagName(tagName: string, message?: string) {
+  doesNotHaveTagName(tagName: string, message?: string): void {
     let element = this.findTargetElement();
     let actual;
     let expected;
@@ -1131,7 +1151,7 @@ export default class DOMAssertions {
   /**
    * @private
    */
-  private pushResult(result) {
+  private pushResult(result: AssertionResult): void {
     this.testContext.pushResult(result);
   }
 
@@ -1146,7 +1166,7 @@ export default class DOMAssertions {
 
     if (el === null) {
       let message = `Element ${this.target || '<unknown>'} should exist`;
-      this.pushResult({ message, result: false });
+      this.pushResult({ message, result: false, actual: undefined, expected: undefined });
       return null;
     }
 
@@ -1190,7 +1210,7 @@ export default class DOMAssertions {
   /**
    * @private
    */
-  private get targetDescription() {
+  private get targetDescription(): string {
     return elementToString(this.target);
   }
 }

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -657,7 +657,7 @@ export default class DOMAssertions {
    */
   doesNotHavePseudoElementStyle(
     selector: string | null,
-    expected: { [key: string]: any },
+    expected: Dictionary<any>,
     message: string
   ): void {
     let element = this.findTargetElement();
@@ -669,7 +669,7 @@ export default class DOMAssertions {
     let result = expectedProperties.some(
       property => computedStyle[property] !== expected[property]
     );
-    let actual: { [key: string]: any } = {};
+    let actual: Dictionary<any> = {};
 
     expectedProperties.forEach(property => (actual[property] = computedStyle[property]));
 

--- a/lib/assertions/exists.ts
+++ b/lib/assertions/exists.ts
@@ -1,12 +1,16 @@
-export default function exists(options, message) {
+import { ExistsOptions } from '../assertions';
+
+export default function exists(options?: ExistsOptions | string, message?: string) {
+  let expectedCount: number = null;
+
   if (typeof options === 'string') {
     message = options;
     options = undefined;
+  } else {
+    expectedCount = options ? options.count : null;
   }
 
   let elements = this.findElements(this.target);
-
-  let expectedCount = options ? options.count : null;
 
   if (expectedCount === null) {
     let result = elements.length > 0;

--- a/lib/assertions/exists.ts
+++ b/lib/assertions/exists.ts
@@ -1,13 +1,12 @@
 import { ExistsOptions } from '../assertions';
 
 export default function exists(options?: ExistsOptions | string, message?: string) {
-  let expectedCount: number = null;
+  let expectedCount: number | null = null;
 
   if (typeof options === 'string') {
     message = options;
-    options = undefined;
-  } else {
-    expectedCount = options ? options.count : null;
+  } else if (options) {
+    expectedCount = options.count;
   }
 
   let elements = this.findElements(this.target);

--- a/lib/assertions/focused.ts
+++ b/lib/assertions/focused.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function focused(message: string) {
+export default function focused(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/focused.ts
+++ b/lib/assertions/focused.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function focused(message) {
+export default function focused(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-checked.ts
+++ b/lib/assertions/is-checked.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function checked(message) {
+export default function checked(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-checked.ts
+++ b/lib/assertions/is-checked.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function checked(message: string) {
+export default function checked(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-disabled.ts
+++ b/lib/assertions/is-disabled.ts
@@ -1,4 +1,4 @@
-export default function isDisabled(message, options: { inverted?: boolean } = {}) {
+export default function isDisabled(message: string, options: { inverted?: boolean } = {}) {
   let { inverted } = options;
 
   let element = this.findTargetElement();

--- a/lib/assertions/is-disabled.ts
+++ b/lib/assertions/is-disabled.ts
@@ -1,4 +1,4 @@
-export default function isDisabled(message: string, options: { inverted?: boolean } = {}) {
+export default function isDisabled(message?: string, options: { inverted?: boolean } = {}) {
   let { inverted } = options;
 
   let element = this.findTargetElement();

--- a/lib/assertions/is-not-checked.ts
+++ b/lib/assertions/is-not-checked.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function notChecked(message) {
+export default function notChecked(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-not-checked.ts
+++ b/lib/assertions/is-not-checked.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function notChecked(message: string) {
+export default function notChecked(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-not-required.ts
+++ b/lib/assertions/is-not-required.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function notRequired(message: string) {
+export default function notRequired(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-not-required.ts
+++ b/lib/assertions/is-not-required.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function notRequired(message) {
+export default function notRequired(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-required.ts
+++ b/lib/assertions/is-required.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function required(message: string) {
+export default function required(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-required.ts
+++ b/lib/assertions/is-required.ts
@@ -1,6 +1,6 @@
 import elementToString from '../helpers/element-to-string';
 
-export default function required(message) {
+export default function required(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/assertions/is-visible.ts
+++ b/lib/assertions/is-visible.ts
@@ -2,13 +2,12 @@ import visible from '../helpers/visible';
 import { ExistsOptions } from '../assertions';
 
 export default function isVisible(options?: string | ExistsOptions, message?: string) {
-  let expectedCount: number = null;
+  let expectedCount: number | null = null;
 
   if (typeof options === 'string') {
     message = options;
-    options = undefined;
-  } else {
-    expectedCount = options ? options.count : null;
+  } else if (options) {
+    expectedCount = options.count;
   }
 
   let elements = this.findElements(this.target).filter(visible);

--- a/lib/assertions/is-visible.ts
+++ b/lib/assertions/is-visible.ts
@@ -1,14 +1,17 @@
 import visible from '../helpers/visible';
+import { ExistsOptions } from '../assertions';
 
-export default function isVisible(options, message) {
+export default function isVisible(options?: string | ExistsOptions, message?: string) {
+  let expectedCount: number = null;
+
   if (typeof options === 'string') {
     message = options;
     options = undefined;
+  } else {
+    expectedCount = options ? options.count : null;
   }
 
   let elements = this.findElements(this.target).filter(visible);
-
-  let expectedCount = options ? options.count : null;
 
   if (expectedCount === null) {
     let result = elements.length > 0;

--- a/lib/assertions/not-focused.ts
+++ b/lib/assertions/not-focused.ts
@@ -1,12 +1,14 @@
-export default function notFocused(message: string) {
+export default function notFocused(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
 
   let result = document.activeElement !== element;
+  let expected = `Element ${this.targetDescription} is not focused`;
+  let actual = result ? expected : `Element ${this.targetDescription} is focused`;
 
   if (!message) {
-    message = `Element ${this.targetDescription} is not focused`;
+    message = expected;
   }
 
-  this.pushResult({ result, message });
+  this.pushResult({ result, message, actual, expected });
 }

--- a/lib/assertions/not-focused.ts
+++ b/lib/assertions/not-focused.ts
@@ -1,4 +1,4 @@
-export default function notFocused(message) {
+export default function notFocused(message: string) {
   let element = this.findTargetElement();
   if (!element) return;
 

--- a/lib/helpers/collapse-whitespace.ts
+++ b/lib/helpers/collapse-whitespace.ts
@@ -1,4 +1,4 @@
-export default function collapseWhitespace(string) {
+export default function collapseWhitespace(string: string): string {
   return string
     .replace(/[\t\r\n]/g, ' ')
     .replace(/ +/g, ' ')

--- a/lib/helpers/element-to-string.ts
+++ b/lib/helpers/element-to-string.ts
@@ -1,7 +1,7 @@
 // imported from https://github.com/nathanboktae/chai-dom
 
-export default function elementToString(el) {
-  let desc;
+export default function elementToString(el: Element | NodeList | string): string {
+  let desc: string;
   if (el instanceof NodeList) {
     if (el.length === 0) {
       return 'empty NodeList';
@@ -23,7 +23,7 @@ export default function elementToString(el) {
   if (el.className && !(el.className instanceof SVGAnimatedString)) {
     desc += `.${String(el.className).replace(/\s+/g, '.')}`;
   }
-  Array.prototype.forEach.call(el.attributes, function(attr) {
+  Array.prototype.forEach.call(el.attributes, function(attr: Attr) {
     if (attr.name !== 'class' && attr.name !== 'id') {
       desc += `[${attr.name}${attr.value ? `="${attr.value}"]` : ']'}`;
     }

--- a/lib/helpers/test-assertions.ts
+++ b/lib/helpers/test-assertions.ts
@@ -1,13 +1,13 @@
-import DOMAssertions from '../assertions';
+import DOMAssertions, { AssertionResult } from '../assertions';
 
 export default class TestAssertions {
-  public results = [];
+  public results: AssertionResult[] = [];
 
-  dom(target, rootElement) {
+  dom(target: string | Element | null, rootElement?: Element) {
     return new DOMAssertions(target, rootElement || document, this as any);
   }
 
-  pushResult(result) {
+  pushResult(result: AssertionResult) {
     this.results.push(result);
   }
 }

--- a/lib/helpers/visible.ts
+++ b/lib/helpers/visible.ts
@@ -1,7 +1,7 @@
 // Visible logic based on jQuery's
 // https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
 
-export default function visible(el: HTMLElement): boolean {
+export default function visible(el: HTMLElement | null): boolean {
   if (el === null) return false;
   if (el.offsetWidth === 0 || el.offsetHeight === 0) return false;
 

--- a/lib/helpers/visible.ts
+++ b/lib/helpers/visible.ts
@@ -1,7 +1,7 @@
 // Visible logic based on jQuery's
 // https://github.com/jquery/jquery/blob/4a2bcc27f9c3ee24b3effac0fbe1285d1ee23cc5/src/css/hiddenVisibleSelectors.js#L11-L13
 
-export default function visible(el) {
+export default function visible(el: HTMLElement): boolean {
   if (el === null) return false;
   if (el.offsetWidth === 0 || el.offsetHeight === 0) return false;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "noImplicitAny": true,
     "declaration": true,
     "lib": [
       "ES6",


### PR DESCRIPTION
I was debugging some type issues I was having and decided to turn on 'noImplicityAny' (considered a best practice in TS). This should tighten up the types to be a lot more useful. I tried to make minimal actual code changes and just do types in this pass.