### PR TITLE
Dropping support for node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "8"
+  - "10"
 
 branches:
   except:

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^3.7.4"
   },
   "engines": {
-    "node": ">= 10.*"
+    "node": "10.* || >= 12.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript": "^3.7.4"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
Removes node 8 support, as it was EOL on 12/31.