### PR TITLE
Fix example for hasProperty

### DIFF
--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -451,7 +451,7 @@ export default class DOMAssertions {
    * @param {string?} message
    *
    * @example
-   * assert.dom('input.password-input').hasAttribute('type', 'password');
+   * assert.dom('input.password-input').hasProperty('type', 'password');
    *
    * @see {@link #doesNotHaveProperty}
    */


### PR DESCRIPTION
The example for hasProperty referenced hasAttribute instead.  This
updates the example to reference the correct function.