### PR TITLE
Add GitHub Actions config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - 'v*'
+  pull_request: {}
+  schedule:
+    - cron: '0 3 * * *' # daily, at 3am
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node: ['10', '12']
+
+    name: Tests (Node.js v${{ matrix.node }})
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: yarn install --no-lockfile
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test:coverage --runInBand
+      - run: yarn test:ember

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: yarn install
+      - run: yarn build
+
+      - name: auto-dist-tag
+        run: |
+          yarn global add auto-dist-tag@1
+          auto-dist-tag --write
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR takes a first stab at converting the existing `.travis.yml` to github actions. I ended up splitting the previous configuration into two:

- CI Build: builds, lints and tests
- Publish: builds, tags, and releases

I'm open to changing any of it.