### PR TITLE
Throw an error if an invalid `rootElement` is passed to `assert.dom()`

### DIFF
--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -12,6 +12,19 @@ QUnit.assert.dom = function(
   target?: string | Element | null,
   rootElement?: Element
 ): DOMAssertions {
+  if (!isValidRootElement(rootElement)) {
+    throw new Error(`${rootElement} is not a valid root element`);
+  }
+
   rootElement = rootElement || this.dom.rootElement || document;
   return new DOMAssertions(target || rootElement, rootElement, this);
 };
+
+function isValidRootElement(element: any): element is Element {
+  return (
+    !element ||
+    (typeof element === 'object' &&
+      typeof element.querySelector === 'function' &&
+      typeof element.querySelectorAll === 'function')
+  );
+}

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -39,5 +39,7 @@ module('Acceptance | qunit-dom', function(hooks) {
      * See this: https://github.com/jsdom/jsdom/issues/1928
      */
     assert.dom('#with-pseudo-element').hasPseudoElementStyle(':after', { content: '";"' });
+
+    assert.throws(() => assert.dom('foo', 'bar'), /bar is not a valid root element/);
   });
 });


### PR DESCRIPTION
Resolves #633 