### PR TITLE
Use `~` constraint for `typescript` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rollup": "^2.9.1",
     "rollup-plugin-typescript2": "^0.27.0",
     "ts-jest": "^25.5.1",
-    "typescript": "^3.8.3"
+    "typescript": "~3.8.3"
   },
   "engines": {
     "node": "10.* || >= 12.*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12712,7 +12712,7 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.8.3:
+typescript@~3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
TypeScript is constantly releasing breaking changes in minor releases, so we should ensure that our TypeScript dependency is always locked to a certain minor version.

This should hopefully also fix our CI issue.