### PR TITLE
Account for null element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
       files: ['**/*.ts'],
       rules: {
         'prefer-const': 'off',
+        'prefer-rest-params': 'off',
 
         // the TypeScript compiler already takes care of this and
         // leaving it enabled results in false positives for interface imports

--- a/lib/__tests__/does-not-have-tagname.ts
+++ b/lib/__tests__/does-not-have-tagname.ts
@@ -59,14 +59,9 @@ describe('assert.dom(...).doesNotHaveTagName()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).doesNotHaveTagName('div');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).doesNotHaveTagName('div')).toThrow(
+        'Null target or element was passed'
+      );
     });
   });
 

--- a/lib/__tests__/does-not-include-text.ts
+++ b/lib/__tests__/does-not-include-text.ts
@@ -59,14 +59,9 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).doesNotIncludeText('foo');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).doesNotIncludeText('foo')).toThrow(
+        'Null target or element was passed'
+      );
     });
   });
 

--- a/lib/__tests__/exists.ts
+++ b/lib/__tests__/exists.ts
@@ -58,19 +58,8 @@ describe('assert.dom(...).exists()', () => {
       ]);
     });
 
-    test('fails if element is missing', () => {
-      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
-
-      assert.dom(null).isVisible();
-
-      expect(assert.results).toEqual([
-        {
-          actual: 'Element <not found> is not visible',
-          expected: 'Element <not found> is visible',
-          message: 'Element <not found> is visible',
-          result: false,
-        },
-      ]);
+    test('fails for missing element', () => {
+      expect(() => assert.dom(null).exists()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/has-tagname.ts
+++ b/lib/__tests__/has-tagname.ts
@@ -59,14 +59,7 @@ describe('assert.dom(...).hasTagName()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).hasTagName('h1');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).hasTagName('h1')).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/has-text-regex.ts
+++ b/lib/__tests__/has-text-regex.ts
@@ -72,14 +72,7 @@ describe('assert.dom(...).hasText()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).hasText(/fo+/);
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).hasText(/fo+/)).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/has-text.ts
+++ b/lib/__tests__/has-text.ts
@@ -59,14 +59,9 @@ describe('assert.dom(...).hasText()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).hasText('Welcome to QUnit');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).hasText('Welcome to QUnit')).toThrow(
+        'Null target or element was passed'
+      );
     });
   });
 

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -72,14 +72,9 @@ describe('assert.dom(...).includesText()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).includesText('foo');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).includesText('foo')).toThrow(
+        'Null target or element was passed'
+      );
     });
   });
 
@@ -125,17 +120,6 @@ describe('assert.dom(...).includesText()', () => {
           actual: 'foo bar',
           expected: 'baz',
           message: 'Element h1.baz has text containing "baz"',
-          result: false,
-        },
-      ]);
-    });
-
-    test('fails for missing element', () => {
-      assert.dom(null).includesText('foo');
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-checked.ts
+++ b/lib/__tests__/is-checked.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isChecked()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isChecked();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isChecked()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-disabled.ts
+++ b/lib/__tests__/is-disabled.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isDisabled()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isDisabled();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isDisabled()).toThrow('Null target or element was passed');
     });
 
     test('succeeds if element is disabled with text', () => {

--- a/lib/__tests__/is-focused.ts
+++ b/lib/__tests__/is-focused.ts
@@ -63,14 +63,7 @@ describe('assert.dom(...).isFocused()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isFocused();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isFocused()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-not-checked.ts
+++ b/lib/__tests__/is-not-checked.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isNotChecked()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isNotChecked();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isNotChecked()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-not-disabled.ts
+++ b/lib/__tests__/is-not-disabled.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isNotDisabled()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isNotDisabled();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isNotDisabled()).toThrow('Null target or element was passed');
     });
 
     test('fails if element is disabled with text', () => {

--- a/lib/__tests__/is-not-focused.ts
+++ b/lib/__tests__/is-not-focused.ts
@@ -63,14 +63,7 @@ describe('assert.dom(...).isNotFocused()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isNotFocused();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isNotFocused()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-not-required.ts
+++ b/lib/__tests__/is-not-required.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isNotRequired()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isNotRequired();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isNotRequired()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-required.ts
+++ b/lib/__tests__/is-required.ts
@@ -60,14 +60,7 @@ describe('assert.dom(...).isRequired()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isRequired();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isRequired()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-valid.ts
+++ b/lib/__tests__/is-valid.ts
@@ -90,14 +90,7 @@ describe('assert.dom(...).isValid()', () => {
     });
 
     test('fails for missing element', () => {
-      assert.dom(null).isValid();
-
-      expect(assert.results).toEqual([
-        {
-          message: 'Element <unknown> should exist',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isValid()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/__tests__/is-visible.ts
+++ b/lib/__tests__/is-visible.ts
@@ -68,18 +68,7 @@ describe('assert.dom(...).isVisible()', () => {
 
   describe('with Element', () => {
     test('fails for missing element', () => {
-      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
-
-      assert.dom(null).isVisible();
-
-      expect(assert.results).toEqual([
-        {
-          actual: 'Element <not found> is not visible',
-          expected: 'Element <not found> is visible',
-          message: 'Element <not found> is visible',
-          result: false,
-        },
-      ]);
+      expect(() => assert.dom(null).isVisible()).toThrow('Null target or element was passed');
     });
   });
 

--- a/lib/helpers/test-assertions.ts
+++ b/lib/helpers/test-assertions.ts
@@ -4,6 +4,10 @@ export default class TestAssertions {
   public results: AssertionResult[] = [];
 
   dom(target: string | Element | null, rootElement?: Element) {
+    if (arguments.length > 0 && arguments[0] === null) {
+      throw new Error('Null target or element was passed');
+    }
+
     return new DOMAssertions(target, rootElement || document, this as any);
   }
 

--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -12,6 +12,10 @@ QUnit.assert.dom = function (
   target?: string | Element | null,
   rootElement?: Element
 ): DOMAssertions {
+  if (arguments.length > 0 && arguments[0] === null) {
+    throw new Error('Null target or element was passed');
+  }
+
   if (!isValidRootElement(rootElement)) {
     throw new Error(`${rootElement} is not a valid root element`);
   }

--- a/tests/acceptance/qunit-dom-test.js
+++ b/tests/acceptance/qunit-dom-test.js
@@ -41,5 +41,6 @@ module('Acceptance | qunit-dom', function (hooks) {
     assert.dom('#with-pseudo-element').hasPseudoElementStyle(':after', { content: '";"' });
 
     assert.throws(() => assert.dom('foo', 'bar'), /bar is not a valid root element/);
+    assert.throws(() => assert.dom(null), /Null target or element was passed/);
   });
 });


### PR DESCRIPTION
Adds null `target|element` detection and error. refs #736 