### PR TITLE
Fix `assert.dom(null).exists()` case

### DIFF
--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -17,7 +17,12 @@ QUnit.assert.dom = function (
   }
 
   rootElement = rootElement || this.dom.rootElement || document;
-  return new DOMAssertions(target || rootElement, rootElement, this);
+
+  if (arguments.length === 0) {
+    target = rootElement;
+  }
+
+  return new DOMAssertions(target, rootElement, this);
 };
 
 function isValidRootElement(element: any): element is Element {


### PR DESCRIPTION
https://github.com/simplabs/qunit-dom/pull/60 unintentionally broke the above case. This commit fixes the implementation by only defaulting to the `rootElement` as `target` when the user hasn't provided any arguments at all.

Resolves #736, Closes #746

/cc @patsy-issa 