### PR TITLE
Update @types/qunit to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@types/jest": "^26.0.14",
-    "@types/qunit": "^2.9.1",
+    "@types/qunit": "^2.9.2",
     "@typescript-eslint/eslint-plugin": "^1.13.0",
     "@typescript-eslint/parser": "^1.13.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2055,10 +2055,10 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
-"@types/qunit@^2.9.1":
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.9.1.tgz#6083a42907ae6c9eecece794844bc3f8659e6c03"
-  integrity sha512-v51Fz/orMOkBGzrRvskky3UN0I81ka6rokAxkcuVyLHAh0qNKp+Roqympg/gTia8vGOIEbeSykevI0VKiIF13Q==
+"@types/qunit@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-2.9.2.tgz#e9293940599848deda9108e00987737d3b780bcc"
+  integrity sha512-GwQibQ0ciNKJ/5beonZ87AiB+/ZbV4DRVWAH9wMUp+K1zRd67LZLH2hKyxj9we3FWH968CYD2tcN2yCitOYp1g==
 
 "@types/range-parser@*":
   version "1.2.3"


### PR DESCRIPTION
The latest version includes the types for the `qunit` module. Prior versions relied on `@types/ember-qunit` to add the `qunit` module, but since this package doesn't use `ember-qunit`'s types we could not import from `qunit` (without adding custom types).