### PR TITLE
Do not default `target` to `document`.

### DIFF
--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -19,7 +19,7 @@ QUnit.assert.dom = function (
   rootElement = rootElement || this.dom.rootElement || document;
 
   if (arguments.length === 0) {
-    target = rootElement;
+    target = rootElement instanceof Element ? rootElement : null;
   }
 
   return new DOMAssertions(target, rootElement, this);


### PR DESCRIPTION
The prior behavior was pretty broken, in the case where `assert.dom()` is called (no arguments) `rootElement` will be `document` for non-Ember users (because `rootElement` falls back to `document`), but our types do not allow `document` for the `target` property of `DOMAssertions`.

It isn't _just_ a types issue though, things like `findElement`/`findElements` actually error if `this.target` is not `null`, a string, or `instanceof Element` (which `document` is not)!

This changes the defaulting to set `target` to the `rootElement` only when it is valid (when its an `Element` instance).