### PR TITLE
containingText selection constraint

### DIFF
--- a/lib/__tests__/containing-text.ts
+++ b/lib/__tests__/containing-text.ts
@@ -1,0 +1,153 @@
+/* eslint-env jest */
+
+import TestAssertions from '../helpers/test-assertions';
+
+describe('assert.dom(...).containingText()...', () => {
+  let assert: TestAssertions;
+
+  beforeEach(() => {
+    assert = new TestAssertions();
+  });
+
+  describe('with string', () => {
+    test('passing', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert.dom('div').containingText('Second').matchesSelector('.b');
+      expect(assert.results).toEqual([
+        {
+          actual: 'The element passed also matches the selector .b.',
+          expected: 'The element passed also matches the selector .b.',
+          message: 'The element passed also matches the selector .b.',
+          result: true,
+        },
+      ]);
+    });
+    test('failing chained assertion', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert.dom('div').containingText('Second').matchesSelector('.a');
+      expect(assert.results).toEqual([
+        {
+          actual: 'The element passed did not also match the selector .a.',
+          expected: 'The element should have matched .a.',
+          message: 'The element passed did not also match the selector .a.',
+          result: false,
+        },
+      ]);
+    });
+
+    test('failing due to no match on initial selector', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert.dom('span').containingText('Second').exists();
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element span containing text Second does not exist',
+          expected: 'Element span containing text Second exists',
+          message: 'Element span containing text Second exists',
+          result: false,
+        },
+      ]);
+    });
+
+    test('failing due to no match on our predicate', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert.dom('div').containingText('nowhere').exists();
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element div containing text nowhere does not exist',
+          expected: 'Element div containing text nowhere exists',
+          message: 'Element div containing text nowhere exists',
+          result: false,
+        },
+      ]);
+    });
+  });
+
+  describe('with regexp', () => {
+    test('passing', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert
+        .dom('div')
+        .containingText(/S.cond/)
+        .matchesSelector('.b');
+      expect(assert.results).toEqual([
+        {
+          actual: 'The element passed also matches the selector .b.',
+          expected: 'The element passed also matches the selector .b.',
+          message: 'The element passed also matches the selector .b.',
+          result: true,
+        },
+      ]);
+    });
+    test('failing', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert
+        .dom('div')
+        .containingText(/S.cond/)
+        .matchesSelector('.a');
+      expect(assert.results).toEqual([
+        {
+          actual: 'The element passed did not also match the selector .a.',
+          expected: 'The element should have matched .a.',
+          message: 'The element passed did not also match the selector .a.',
+          result: false,
+        },
+      ]);
+    });
+    test('failing due to no match on initial selector', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert
+        .dom('span')
+        .containingText(/S.cond/)
+        .exists();
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element span containing text /S.cond/ does not exist',
+          expected: 'Element span containing text /S.cond/ exists',
+          message: 'Element span containing text /S.cond/ exists',
+          result: false,
+        },
+      ]);
+    });
+
+    test('failing due to no match on our predicate', () => {
+      document.body.innerHTML =
+        '<article><div class="a">\nFirst\n</div><div class="b">\nSecond\n</div></article>';
+
+      assert
+        .dom('div')
+        .containingText(/nowhere/)
+        .exists();
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element div containing text /nowhere/ does not exist',
+          expected: 'Element div containing text /nowhere/ exists',
+          message: 'Element div containing text /nowhere/ exists',
+          result: false,
+        },
+      ]);
+    });
+  });
+
+  describe('invalid arguments to `containingText`', () => {
+    test('passing undefined to `containingText` will throw an error', () => {
+      //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
+      expect(() => assert.dom('div').containingText().hasText(1234)).toThrow(
+        'You must pass a string or Regular Expression to "containingText". You passed undefined'
+      );
+    });
+  });
+});

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -32,7 +32,8 @@ export default class DOMAssertions {
   constructor(
     private target: string | Element | null,
     private rootElement: Element | Document,
-    private testContext: Assert
+    private testContext: Assert,
+    private targetDescription = elementToString(target)
   ) {}
 
   /**
@@ -1336,6 +1337,38 @@ export default class DOMAssertions {
   }
 
   /**
+   * Narrows your selection to the first matching Element that contains the
+   * given text. By itself, this is not an assertion. Chain other assertions
+   * after it.
+   *
+   * @param {string|RegExp} text
+   *
+   * @example
+   *
+   * assert.dom('button').containingText('Subscribe').hasAttribute('disabled');
+   */
+  containingText(expected: string | RegExp): DOMAssertions {
+    let predicate: (element: Element) => boolean;
+    if (typeof expected === 'string') {
+      let collapsedExpected = collapseWhitespace(expected);
+      predicate = element => collapseWhitespace(element.textContent) === collapsedExpected;
+    } else if (expected instanceof RegExp) {
+      predicate = element => expected.test(element.textContent);
+    } else {
+      throw new Error(
+        `You must pass a string or Regular Expression to "containingText". You passed ${expected}`
+      );
+    }
+    let target = this.findElements().find(predicate);
+    return new DOMAssertions(
+      target || null,
+      this.rootElement,
+      this.testContext,
+      `${this.targetDescription} containing text ${expected}`
+    );
+  }
+
+  /**
    * @private
    */
   private pushResult(result: AssertionResult): void {
@@ -1394,12 +1427,5 @@ export default class DOMAssertions {
     } else {
       throw new TypeError(`Unexpected Parameter: ${this.target}`);
     }
-  }
-
-  /**
-   * @private
-   */
-  private get targetDescription(): string {
-    return elementToString(this.target);
   }
 }


### PR DESCRIPTION
This adds the ability to restrict your selection to the first element that contains the given text.

```js
assert.dom('button').containingText('submit').hasAttribute('disabled');
```

This gives a reasonable replacement for the never-standardized `:contains()` selector that was implemented [in jQuery](https://api.jquery.com/contains-selector/). I have been missing it.