### PR TITLE
Extract contributing instructions to separate file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+## How to run tests
+
+```bash
+yarn test
+```
+
+## How to generate the documentation
+
+The contents of [API.md](API.md) are generated from comments in the source code.
+To update API.md, run the following command:
+
+```bash
+yarn docs
+```

--- a/README.md
+++ b/README.md
@@ -102,17 +102,7 @@ file yet.
 Contributing
 ------------------------------------------------------------------------------
 
-### How to Run Tests
-
-```bash
-yarn test
-```
-
-### How to Generate the Documentation
-
-```bash
-yarn docs
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Related
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Moves instructors for contributors to its own file as discussed.
I left the header in README to make it easier to scan.