### PR TITLE
External query

### DIFF
--- a/API.md
+++ b/API.md
@@ -115,6 +115,10 @@
     -   [doesNotHaveTagName][111]
         -   [Parameters][112]
         -   [Examples][113]
+-   [ExternalQuery][114]
+    -   [elements][115]
+    -   [element (optional)][116]
+    -   [elementsDescription (optional)][117]
 
 ## assert.dom()
 
@@ -122,8 +126,8 @@ Once installed the DOM element assertions are available at `assert.dom(...).*`:
 
 **Parameters**
 
--   `target` **([string][114] \| [HTMLElement][115])** A CSS selector that can be used to find elements using [`querySelector()`][116], or an [HTMLElement][] (Not all assertions support both target types.) (optional, default `rootElement` or `document`)
--   `rootElement` **[HTMLElement][115]?** The root element of the DOM in which to search for the `target` (optional, default `document`)
+-   `target` **([string][118] \| [HTMLElement][119] \| [ExternalQuery][120])** A CSS selector that can be used to find elements using [`querySelector()`][121], or an [HTMLElement][], or an [ExternalQuery][] (optional, default `rootElement` or `document`)
+-   `rootElement` **[HTMLElement][119]?** The root element of the DOM in which to search for the `target` (optional, default `document`)
 
 **Examples**
 
@@ -138,16 +142,16 @@ test('the title exists', function(assert) {
 
 ### exists
 
--   **See: [#doesNotExist][117]
+-   **See: [#doesNotExist][122]
     **
 
-Assert an [HTMLElement][118] (or multiple) matching the `selector` exists.
+Assert an [HTMLElement][123] (or multiple) matching the `selector` exists.
 
 #### Parameters
 
--   `options` **[object][119]?** 
-    -   `options.count` **[number][120]?** 
--   `message` **[string][121]?** 
+-   `options` **[object][124]?** 
+    -   `options.count` **[number][125]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -161,11 +165,11 @@ assert.dom('.choice').exists({ count: 4 });
 -   **See: [#exists][3]
     **
 
-Assert an [HTMLElement][118] matching the `selector` does not exists.
+Assert an [HTMLElement][123] matching the `selector` does not exists.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -175,17 +179,17 @@ assert.dom('.should-not-exist').doesNotExist();
 
 ### isChecked
 
--   **See: [#isNotChecked][122]
+-   **See: [#isNotChecked][127]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is currently checked.
 
 Note: This also supports `aria-checked="true/false"`.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -195,17 +199,17 @@ assert.dom('input.active').isChecked();
 
 ### isNotChecked
 
--   **See: [#isChecked][123]
+-   **See: [#isChecked][128]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is currently unchecked.
 
 Note: This also supports `aria-checked="true/false"`.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -215,15 +219,15 @@ assert.dom('input.active').isNotChecked();
 
 ### isFocused
 
--   **See: [#isNotFocused][124]
+-   **See: [#isNotFocused][129]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is currently focused.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -233,15 +237,15 @@ assert.dom('input.email').isFocused();
 
 ### isNotFocused
 
--   **See: [#isFocused][125]
+-   **See: [#isFocused][130]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is not currently focused.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -251,15 +255,15 @@ assert.dom('input[type="password"]').isNotFocused();
 
 ### isRequired
 
--   **See: [#isNotRequired][126]
+-   **See: [#isNotRequired][131]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is currently required.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -269,15 +273,15 @@ assert.dom('input[type="text"]').isRequired();
 
 ### isNotRequired
 
--   **See: [#isRequired][127]
+-   **See: [#isRequired][132]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is currently not required.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -287,10 +291,10 @@ assert.dom('input[type="text"]').isNotRequired();
 
 ### isValid
 
--   **See: [#isValid][128]
+-   **See: [#isValid][133]
     **
 
-Assert that the [HTMLElement][118] passes validation
+Assert that the [HTMLElement][123] passes validation
 
 Validity is determined by asserting that:
 
@@ -298,7 +302,7 @@ Validity is determined by asserting that:
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -308,10 +312,10 @@ assert.dom('.input').isValid();
 
 ### isNotValid
 
--   **See: [#isValid][128]
+-   **See: [#isValid][133]
     **
 
-Assert that the [HTMLElement][118] does not pass validation
+Assert that the [HTMLElement][123] does not pass validation
 
 Validity is determined by asserting that:
 
@@ -319,7 +323,7 @@ Validity is determined by asserting that:
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -329,10 +333,10 @@ assert.dom('.input').isNotValid();
 
 ### isVisible
 
--   **See: [#isNotVisible][129]
+-   **See: [#isNotVisible][134]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` exists and is visible.
 
 Visibility is determined by asserting that:
@@ -345,9 +349,9 @@ but not necessarily in the viewport.
 
 #### Parameters
 
--   `options` **[object][119]?** 
-    -   `options.count` **[number][120]?** 
--   `message` **[string][121]?** 
+-   `options` **[object][124]?** 
+    -   `options.count` **[number][125]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -358,10 +362,10 @@ assert.dom('.choice').isVisible({ count: 4 });
 
 ### isNotVisible
 
--   **See: [#isVisible][130]
+-   **See: [#isVisible][135]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` does not exist or is not visible on the page.
 
 Visibility is determined by asserting that:
@@ -374,7 +378,7 @@ but not necessarily in the viewport.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -384,18 +388,18 @@ assert.dom('.foo').isNotVisible();
 
 ### hasAttribute
 
--   **See: [#doesNotHaveAttribute][131]
+-   **See: [#doesNotHaveAttribute][136]
     **
 
-Assert that the [HTMLElement][118] has an attribute with the provided `name`
+Assert that the [HTMLElement][123] has an attribute with the provided `name`
 and optionally checks if the attribute `value` matches the provided text
 or regular expression.
 
 #### Parameters
 
--   `name` **[string][121]** 
--   `value` **([string][121] \| [RegExp][132] \| [object][119]?)** 
--   `message` **[string][121]?** 
+-   `name` **[string][126]** 
+-   `value` **([string][126] \| [RegExp][137] \| [object][124]?)** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -405,17 +409,17 @@ assert.dom('input.password-input').hasAttribute('type', 'password');
 
 ### doesNotHaveAttribute
 
--   **See: [#hasAttribute][133]
+-   **See: [#hasAttribute][138]
     **
 
-Assert that the [HTMLElement][118] has no attribute with the provided `name`.
+Assert that the [HTMLElement][123] has no attribute with the provided `name`.
 
 **Aliases:** `hasNoAttribute`, `lacksAttribute`
 
 #### Parameters
 
--   `name` **[string][121]** 
--   `message` **[string][121]?** 
+-   `name` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -425,18 +429,18 @@ assert.dom('input.username').hasNoAttribute('disabled');
 
 ### hasAria
 
--   **See: [#hasNoAria][134]
+-   **See: [#hasNoAria][139]
     **
 
-Assert that the [HTMLElement][118] has an ARIA attribute with the provided
+Assert that the [HTMLElement][123] has an ARIA attribute with the provided
 `name` and optionally checks if the attribute `value` matches the provided
 text or regular expression.
 
 #### Parameters
 
--   `name` **[string][121]** 
--   `value` **([string][121] \| [RegExp][132] \| [object][119]?)** 
--   `message` **[string][121]?** 
+-   `name` **[string][126]** 
+-   `value` **([string][126] \| [RegExp][137] \| [object][124]?)** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -446,16 +450,16 @@ assert.dom('button').hasAria('pressed', 'true');
 
 ### doesNotHaveAria
 
--   **See: [#hasAria][135]
+-   **See: [#hasAria][140]
     **
 
-Assert that the [HTMLElement][118] has no ARIA attribute with the
+Assert that the [HTMLElement][123] has no ARIA attribute with the
 provided `name`.
 
 #### Parameters
 
--   `name` **[string][121]** 
--   `message` **[string][121]?** 
+-   `name` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -465,18 +469,18 @@ assert.dom('button').doesNotHaveAria('pressed');
 
 ### hasProperty
 
--   **See: [#doesNotHaveProperty][136]
+-   **See: [#doesNotHaveProperty][141]
     **
 
-Assert that the [HTMLElement][118] has a property with the provided `name`
+Assert that the [HTMLElement][123] has a property with the provided `name`
 and checks if the property `value` matches the provided text or regular
 expression.
 
 #### Parameters
 
--   `name` **[string][121]** 
--   `value` **([RegExp][132] | any)** 
--   `message` **[string][121]?** 
+-   `name` **[string][126]** 
+-   `value` **([RegExp][137] | any)** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -486,15 +490,15 @@ assert.dom('input.password-input').hasProperty('type', 'password');
 
 ### isDisabled
 
--   **See: [#isNotDisabled][137]
+-   **See: [#isNotDisabled][142]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is disabled.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -504,17 +508,17 @@ assert.dom('.foo').isDisabled();
 
 ### isNotDisabled
 
--   **See: [#isDisabled][138]
+-   **See: [#isDisabled][143]
     **
 
-Assert that the [HTMLElement][118] or an [HTMLElement][118] matching the
+Assert that the [HTMLElement][123] or an [HTMLElement][123] matching the
 `selector` is not disabled.
 
 **Aliases:** `isEnabled`
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -524,19 +528,19 @@ assert.dom('.foo').isNotDisabled();
 
 ### hasClass
 
--   **See: [#doesNotHaveClass][139]
+-   **See: [#doesNotHaveClass][144]
     **
 
-Assert that the [HTMLElement][118] has the `expected` CSS class using
-[`classList`][140].
+Assert that the [HTMLElement][123] has the `expected` CSS class using
+[`classList`][145].
 
 `expected` can also be a regular expression, and the assertion will return
 true if any of the element's CSS classes match.
 
 #### Parameters
 
--   `expected` **([string][121] \| [RegExp][132])** 
--   `message` **[string][121]?** 
+-   `expected` **([string][126] \| [RegExp][137])** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -550,11 +554,11 @@ assert.dom('input[type="password"]').hasClass(/.*password-input/);
 
 ### doesNotHaveClass
 
--   **See: [#hasClass][141]
+-   **See: [#hasClass][146]
     **
 
-Assert that the [HTMLElement][118] does not have the `expected` CSS class using
-[`classList`][140].
+Assert that the [HTMLElement][123] does not have the `expected` CSS class using
+[`classList`][145].
 
 `expected` can also be a regular expression, and the assertion will return
 true if none of the element's CSS classes match.
@@ -563,8 +567,8 @@ true if none of the element's CSS classes match.
 
 #### Parameters
 
--   `expected` **([string][121] \| [RegExp][132])** 
--   `message` **[string][121]?** 
+-   `expected` **([string][126] \| [RegExp][137])** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -578,16 +582,16 @@ assert.dom('input[type="password"]').doesNotHaveClass(/username-.*-input/);
 
 ### hasStyle
 
--   **See: [#hasClass][141]
+-   **See: [#hasClass][146]
     **
 
 Assert that the [HTMLElement][] has the `expected` style declarations using
-[`window.getComputedStyle`][142].
+[`window.getComputedStyle`][147].
 
 #### Parameters
 
--   `expected` **[object][119]** 
--   `message` **[string][121]?** 
+-   `expected` **[object][124]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -600,17 +604,17 @@ assert.dom('.progress-bar').hasStyle({
 
 ### hasPseudoElementStyle
 
--   **See: [#hasClass][141]
+-   **See: [#hasClass][146]
     **
 
 Assert that the pseudo element for `selector` of the [HTMLElement][] has the `expected` style declarations using
-[`window.getComputedStyle`][142].
+[`window.getComputedStyle`][147].
 
 #### Parameters
 
--   `selector` **[string][121]** 
--   `expected` **[object][119]** 
--   `message` **[string][121]?** 
+-   `selector` **[string][126]** 
+-   `expected` **[object][124]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -622,16 +626,16 @@ assert.dom('.progress-bar').hasPseudoElementStyle(':after', {
 
 ### doesNotHaveStyle
 
--   **See: [#hasClass][141]
+-   **See: [#hasClass][146]
     **
 
 Assert that the [HTMLElement][] does not have the `expected` style declarations using
-[`window.getComputedStyle`][142].
+[`window.getComputedStyle`][147].
 
 #### Parameters
 
--   `expected` **[object][119]** 
--   `message` **[string][121]?** 
+-   `expected` **[object][124]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -644,17 +648,17 @@ assert.dom('.progress-bar').doesNotHaveStyle({
 
 ### doesNotHavePseudoElementStyle
 
--   **See: [#hasClass][141]
+-   **See: [#hasClass][146]
     **
 
 Assert that the pseudo element for `selector` of the [HTMLElement][] does not have the `expected` style declarations using
-[`window.getComputedStyle`][142].
+[`window.getComputedStyle`][147].
 
 #### Parameters
 
--   `selector` **[string][121]** 
--   `expected` **[object][119]** 
--   `message` **[string][121]?** 
+-   `selector` **[string][126]** 
+-   `expected` **[object][124]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -666,12 +670,12 @@ assert.dom('.progress-bar').doesNotHavePseudoElementStyle(':after', {
 
 ### hasText
 
--   **See: [#includesText][143]
+-   **See: [#includesText][148]
     **
 
-Assert that the text of the [HTMLElement][118] or an [HTMLElement][118]
+Assert that the text of the [HTMLElement][123] or an [HTMLElement][123]
 matching the `selector` matches the `expected` text, using the
-[`textContent`][144]
+[`textContent`][149]
 attribute and stripping/collapsing whitespace.
 
 `expected` can also be a regular expression.
@@ -684,8 +688,8 @@ attribute and stripping/collapsing whitespace.
 
 #### Parameters
 
--   `expected` **([string][121] \| [RegExp][132])** 
--   `message` **[string][121]?** 
+-   `expected` **([string][126] \| [RegExp][137])** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -703,14 +707,14 @@ assert.dom('.foo').hasText(/[12]\d{3}/);
 
 ### hasAnyText
 
--   **See: [#hasText][145]
+-   **See: [#hasText][150]
     **
 
-Assert that the `textContent` property of an [HTMLElement][118] is not empty.
+Assert that the `textContent` property of an [HTMLElement][123] is not empty.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -720,14 +724,14 @@ assert.dom('button.share').hasAnyText();
 
 ### hasNoText
 
--   **See: [#hasNoText][146]
+-   **See: [#hasNoText][151]
     **
 
-Assert that the `textContent` property of an [HTMLElement][118] is empty.
+Assert that the `textContent` property of an [HTMLElement][123] is empty.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -737,25 +741,25 @@ assert.dom('div').hasNoText();
 
 ### includesText
 
--   **See: [#hasText][145]
+-   **See: [#hasText][150]
     **
 
-Assert that the text of the [HTMLElement][118] or an [HTMLElement][118]
+Assert that the text of the [HTMLElement][123] or an [HTMLElement][123]
 matching the `selector` contains the given `text`, using the
-[`textContent`][144]
+[`textContent`][149]
 attribute.
 
 > Note: This assertion will collapse whitespace in `textContent` before searching.
 > If you would like to assert on a string that _should_ contain line breaks, tabs,
-> more than one space in a row, or starting/ending whitespace, use the [#hasText][145]
+> more than one space in a row, or starting/ending whitespace, use the [#hasText][150]
 > selector and pass your expected text in as a RegEx pattern.
 
 **Aliases:** `containsText`, `hasTextContaining`
 
 #### Parameters
 
--   `text` **[string][121]** 
--   `message` **[string][121]?** 
+-   `text` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -765,17 +769,17 @@ assert.dom('#title').includesText('Welcome');
 
 ### doesNotIncludeText
 
-Assert that the text of the [HTMLElement][118] or an [HTMLElement][118]
+Assert that the text of the [HTMLElement][123] or an [HTMLElement][123]
 matching the `selector` does not include the given `text`, using the
-[`textContent`][144]
+[`textContent`][149]
 attribute.
 
 **Aliases:** `doesNotContainText`, `doesNotHaveTextContaining`
 
 #### Parameters
 
--   `text` **[string][121]** 
--   `message` **[string][121]?** 
+-   `text` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -785,12 +789,12 @@ assert.dom('#title').doesNotIncludeText('Welcome');
 
 ### hasValue
 
--   **See: [#hasAnyValue][147]
+-   **See: [#hasAnyValue][152]
     **
--   **See: [#hasNoValue][148]
+-   **See: [#hasNoValue][153]
     **
 
-Assert that the `value` property of an [HTMLInputElement][149] matches
+Assert that the `value` property of an [HTMLInputElement][154] matches
 the `expected` text or regular expression.
 
 If no `expected` value is provided, the assertion will fail if the
@@ -798,8 +802,8 @@ If no `expected` value is provided, the assertion will fail if the
 
 #### Parameters
 
--   `expected` **([string][121] \| [RegExp][132] \| [object][119]?)** 
--   `message` **[string][121]?** 
+-   `expected` **([string][126] \| [RegExp][137] \| [object][124]?)** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -809,16 +813,16 @@ assert.dom('input.username').hasValue('HSimpson');
 
 ### hasAnyValue
 
--   **See: [#hasValue][150]
+-   **See: [#hasValue][155]
     **
--   **See: [#hasNoValue][148]
+-   **See: [#hasNoValue][153]
     **
 
-Assert that the `value` property of an [HTMLInputElement][149] is not empty.
+Assert that the `value` property of an [HTMLInputElement][154] is not empty.
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -828,18 +832,18 @@ assert.dom('input.username').hasAnyValue();
 
 ### hasNoValue
 
--   **See: [#hasValue][150]
+-   **See: [#hasValue][155]
     **
--   **See: [#hasAnyValue][147]
+-   **See: [#hasAnyValue][152]
     **
 
-Assert that the `value` property of an [HTMLInputElement][149] is empty.
+Assert that the `value` property of an [HTMLInputElement][154] is empty.
 
 **Aliases:** `lacksValue`
 
 #### Parameters
 
--   `message` **[string][121]?** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -854,8 +858,8 @@ compareSelector.
 
 #### Parameters
 
--   `compareSelector` **[string][121]** 
--   `message` **[string][121]?** 
+-   `compareSelector` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -870,8 +874,8 @@ compareSelector.
 
 #### Parameters
 
--   `compareSelector` **[string][121]** 
--   `message` **[string][121]?** 
+-   `compareSelector` **[string][126]** 
+-   `message` **[string][126]?** 
 
 #### Examples
 
@@ -881,16 +885,16 @@ assert.dom('input').doesNotMatchSelector('input[disabled]')
 
 ### hasTagName
 
-Assert that the tagName of the [HTMLElement][118] or an [HTMLElement][118]
+Assert that the tagName of the [HTMLElement][123] or an [HTMLElement][123]
 matching the `selector` matches the `expected` tagName, using the
-[`tagName`][151]
-property of the [HTMLElement][118].
+[`tagName`][156]
+property of the [HTMLElement][123].
 
 #### Parameters
 
 -   `tagName`  
--   `message` **[string][121]?** 
--   `expected` **[string][121]** 
+-   `message` **[string][126]?** 
+-   `expected` **[string][126]** 
 
 #### Examples
 
@@ -904,16 +908,16 @@ assert.dom('#title').hasTagName('h1');
 
 ### doesNotHaveTagName
 
-Assert that the tagName of the [HTMLElement][118] or an [HTMLElement][118]
+Assert that the tagName of the [HTMLElement][123] or an [HTMLElement][123]
 matching the `selector` does not match the `expected` tagName, using the
-[`tagName`][151]
-property of the [HTMLElement][118].
+[`tagName`][156]
+property of the [HTMLElement][123].
 
 #### Parameters
 
 -   `tagName`  
--   `message` **[string][121]?** 
--   `expected` **[string][121]** 
+-   `message` **[string][126]?** 
+-   `expected` **[string][126]** 
 
 #### Examples
 
@@ -924,6 +928,60 @@ property of the [HTMLElement][118].
 
 assert.dom('section#block').doesNotHaveTagName('div');
 ```
+
+## ExternalQuery
+
+An interface for external query implementations, allowing `qunit-dom` to
+run assertions on objects wrapping DOM elements/queries such as page object
+implementations.
+
+At a minimum, implementations must provide the `elements` property, and
+`qunit-dom` can fill in the other functionality with reasonable
+assumptions/defaults.
+
+Example:
+
+```javascript
+function withText(selector, text) {
+  let els = Array.from(document.querySelectorAll(selector));
+  return {
+    elements: els.filter(e => e.textContent.includes('submit')),
+    elementsDescription: `${selector}:contains(${text})`
+  };
+}
+
+assert.dom(withText('button', 'save')).exists();
+```
+
+
+### elements
+
+The DOM elements matched when executing this query as a multiple-element
+query, analagous to `querySelectorAll()`
+
+Type: ([NodeList][157] \| [Element][158]\[])
+
+
+### element (optional)
+
+The DOM element (or null) matched when executing this query as a
+single-element query, analagous to `querySelector()`. If not supplied, the
+value will default to `elements[0]`. This property can be implemented to
+achieve better performance since almost all of `qunit-dom`'s assertions run
+single-element queries.
+
+Type: ([Element][158] | null)
+
+
+### elementsDescription (optional)
+
+A string describing the matched elements, e.g. the selector used to query
+them. If not supplied, then `qunit-dom` will generate a description by
+inspecting the first matching element and reading various properties and
+attributes off of it.
+
+Type: [string][159]
+
 
 [1]: #assertdom
 
@@ -1151,78 +1209,94 @@ assert.dom('section#block').doesNotHaveTagName('div');
 
 [113]: #examples-36
 
-[114]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
+[114]: #externalquery
 
-[115]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+[115]: #elements
 
-[116]: https://developer.mozilla.org/de/docs/Web/API/Document/querySelector
+[116]: #element-optional
 
-[117]: #doesNotExist
+[117]: #elementsdescription-optional
 
-[118]: https://developer.mozilla.org/docs/Web/HTML/Element
+[118]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[119]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
+[119]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element
 
-[120]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
+[120]: #ExternalQuery
 
-[121]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
+[121]: https://developer.mozilla.org/de/docs/Web/API/Document/querySelector
 
-[122]: #isNotChecked
+[122]: #doesNotExist
 
-[123]: #isChecked
+[123]: https://developer.mozilla.org/docs/Web/HTML/Element
 
-[124]: #isNotFocused
+[124]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[125]: #isFocused
+[125]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[126]: #isNotRequired
+[126]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String
 
-[127]: #isRequired
+[127]: #isNotChecked
 
-[128]: #isValid
+[128]: #isChecked
 
-[129]: #isNotVisible
+[129]: #isNotFocused
 
-[130]: #isVisible
+[130]: #isFocused
 
-[131]: #doesNotHaveAttribute
+[131]: #isNotRequired
 
-[132]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+[132]: #isRequired
 
-[133]: #hasAttribute
+[133]: #isValid
 
-[134]: #hasNoAria
+[134]: #isNotVisible
 
-[135]: #hasAria
+[135]: #isVisible
 
-[136]: #doesNotHaveProperty
+[136]: #doesNotHaveAttribute
 
-[137]: #isNotDisabled
+[137]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
-[138]: #isDisabled
+[138]: #hasAttribute
 
-[139]: #doesNotHaveClass
+[139]: #hasNoAria
 
-[140]: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
+[140]: #hasAria
 
-[141]: #hasClass
+[141]: #doesNotHaveProperty
 
-[142]: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle
+[142]: #isNotDisabled
 
-[143]: #includesText
+[143]: #isDisabled
 
-[144]: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
+[144]: #doesNotHaveClass
 
-[145]: #hasText
+[145]: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList
 
-[146]: #hasNoText
+[146]: #hasClass
 
-[147]: #hasAnyValue
+[147]: https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle
 
-[148]: #hasNoValue
+[148]: #includesText
 
-[149]: https://developer.mozilla.org/docs/Web/API/HTMLInputElement
+[149]: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent
 
-[150]: #hasValue
+[150]: #hasText
 
-[151]: https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName
+[151]: #hasNoText
+
+[152]: #hasAnyValue
+
+[153]: #hasNoValue
+
+[154]: https://developer.mozilla.org/docs/Web/API/HTMLInputElement
+
+[155]: #hasValue
+
+[156]: https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName
+
+[157]: https://developer.mozilla.org/docs/Web/API/NodeList
+
+[158]: https://developer.mozilla.org/docs/Web/API/Element
+
+[159]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String

--- a/documentation.yml
+++ b/documentation.yml
@@ -5,7 +5,7 @@ toc:
 
       **Parameters**
 
-      -   `target` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element))** A CSS selector that can be used to find elements using [`querySelector()`](https://developer.mozilla.org/de/docs/Web/API/Document/querySelector), or an [HTMLElement][] (Not all assertions support both target types.) (optional, default `rootElement` or `document`)
+      -   `target` **([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) \| [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element) \| [ExternalQuery](#ExternalQuery))** A CSS selector that can be used to find elements using [`querySelector()`](https://developer.mozilla.org/de/docs/Web/API/Document/querySelector), or an [HTMLElement][], or an [ExternalQuery][] (optional, default `rootElement` or `document`)
       -   `rootElement` **[HTMLElement](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)?** The root element of the DOM in which to search for the `target` (optional, default `document`)
 
       **Examples**
@@ -15,3 +15,60 @@ toc:
         assert.dom('#title').exists();
       });
       ```
+  - DOMAssertions
+  # documentation.js throws an error if we give it both .js and .ts files as
+  # inputs
+  # (https://github.com/documentationjs/documentation/issues/1272#issuecomment-520031093),
+  # so as long as we're running it against the generated dist/ .js code, we
+  # can't auto-document typescript interfaces. This documentation was adapted
+  # from the output of
+  # ```
+  # yarn documentation build lib/query.ts --parse-extension ts --infer-private '(SelectorQuery|ElementQuery|WrappedQuery)' -f md
+  # ```
+  - name: ExternalQuery
+    description: |
+      An interface for external query implementations, allowing `qunit-dom` to
+      run assertions on objects wrapping DOM elements/queries such as page object
+      implementations.
+
+      At a minimum, implementations must provide the `elements` property, and
+      `qunit-dom` can fill in the other functionality with reasonable
+      assumptions/defaults.
+
+      Example:
+
+      ```javascript
+      function withText(selector, text) {
+        let els = Array.from(document.querySelectorAll(selector));
+        return {
+          elements: els.filter(e => e.textContent.includes('submit')),
+          elementsDescription: `${selector}:contains(${text})`
+        };
+      }
+
+      assert.dom(withText('button', 'save')).exists();
+      ```
+    children:
+      - name: elements
+        description: |
+          The DOM elements matched when executing this query as a multiple-element
+          query, analagous to `querySelectorAll()`
+
+          Type: ([NodeList](https://developer.mozilla.org/docs/Web/API/NodeList) | [Element](https://developer.mozilla.org/docs/Web/API/Element)[])
+      - name: element (optional)
+        description: |
+          The DOM element (or null) matched when executing this query as a
+          single-element query, analagous to `querySelector()`. If not supplied, the
+          value will default to `elements[0]`. This property can be implemented to
+          achieve better performance since almost all of `qunit-dom`'s assertions run
+          single-element queries.
+
+          Type: ([Element](https://developer.mozilla.org/docs/Web/API/Element) | null)
+      - name: elementsDescription (optional)
+        description: |
+          A string describing the matched elements, e.g. the selector used to query
+          them. If not supplied, then `qunit-dom` will generate a description by
+          inspecting the first matching element and reading various properties and
+          attributes off of it.
+
+          Type: [string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)

--- a/lib/__tests__/does-not-have-tagname.ts
+++ b/lib/__tests__/does-not-have-tagname.ts
@@ -63,7 +63,7 @@ describe('assert.dom(...).doesNotHaveTagName()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/does-not-include-text.ts
+++ b/lib/__tests__/does-not-include-text.ts
@@ -63,7 +63,7 @@ describe('assert.dom(...).doesNotIncludeText()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/has-tagname.ts
+++ b/lib/__tests__/has-tagname.ts
@@ -63,7 +63,7 @@ describe('assert.dom(...).hasTagName()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/has-text-regex.ts
+++ b/lib/__tests__/has-text-regex.ts
@@ -76,7 +76,7 @@ describe('assert.dom(...).hasText()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/has-text.ts
+++ b/lib/__tests__/has-text.ts
@@ -63,7 +63,7 @@ describe('assert.dom(...).hasText()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -76,7 +76,7 @@ describe('assert.dom(...).includesText()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);
@@ -135,7 +135,7 @@ describe('assert.dom(...).includesText()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-checked.ts
+++ b/lib/__tests__/is-checked.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isChecked()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-disabled.ts
+++ b/lib/__tests__/is-disabled.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isDisabled()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-focused.ts
+++ b/lib/__tests__/is-focused.ts
@@ -67,7 +67,7 @@ describe('assert.dom(...).isFocused()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-not-checked.ts
+++ b/lib/__tests__/is-not-checked.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isNotChecked()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-not-disabled.ts
+++ b/lib/__tests__/is-not-disabled.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isNotDisabled()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-not-focused.ts
+++ b/lib/__tests__/is-not-focused.ts
@@ -67,7 +67,7 @@ describe('assert.dom(...).isNotFocused()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-not-required.ts
+++ b/lib/__tests__/is-not-required.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isNotRequired()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-not-valid.ts
+++ b/lib/__tests__/is-not-valid.ts
@@ -94,7 +94,7 @@ describe('assert.dom(...).isNotValid()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-required.ts
+++ b/lib/__tests__/is-required.ts
@@ -64,7 +64,7 @@ describe('assert.dom(...).isRequired()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/is-valid.ts
+++ b/lib/__tests__/is-valid.ts
@@ -94,7 +94,7 @@ describe('assert.dom(...).isValid()', () => {
 
       expect(assert.results).toEqual([
         {
-          message: 'Element <unknown> should exist',
+          message: 'Element <not found> should exist',
           result: false,
         },
       ]);

--- a/lib/__tests__/query.ts
+++ b/lib/__tests__/query.ts
@@ -1,0 +1,197 @@
+/* eslint-env jest */
+
+import { createQuery } from '../query';
+import TestAssertions from '../helpers/test-assertions';
+
+describe('createQuery()', () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div class="single"></div><div class="multiple"></div><div class="multiple"></div>';
+  });
+
+  describe('element/elements', () => {
+    test('single element matching', () => {
+      let selector = createQuery('.single', document);
+      let element = createQuery(document.querySelector('.single'), document);
+      let wrapper = createQuery({ elements: [document.querySelector('.single')] }, document);
+
+      let expected = document.querySelector('.single');
+
+      expect(selector.element).toEqual(expected);
+      expect(element.element).toEqual(expected);
+      expect(wrapper.element).toEqual(expected);
+
+      expect(selector.elements).toEqual([expected]);
+      expect(element.elements).toEqual([expected]);
+      expect(wrapper.elements).toEqual([expected]);
+    });
+
+    test('multiple element matching', () => {
+      let selector = createQuery('.multiple', document);
+      // No equivalent for element query
+      let wrapper = createQuery(
+        { elements: Array.from(document.querySelectorAll('.multiple')) },
+        document
+      );
+
+      let expected = Array.from(document.querySelectorAll('.multiple'));
+
+      expect(selector.element).toEqual(expected[0]);
+      expect(wrapper.element).toEqual(expected[0]);
+
+      expect(selector.elements).toEqual(expected);
+      expect(wrapper.elements).toEqual(expected);
+    });
+
+    test('no element matching', () => {
+      let selector = createQuery('.none', document);
+      let element = createQuery(document.querySelector('.none'), document);
+      let wrapper = createQuery(
+        { elements: Array.from(document.querySelectorAll('.none')) },
+        document
+      );
+
+      expect(selector.element).toEqual(null);
+      expect(element.element).toEqual(null);
+      expect(wrapper.element).toEqual(null);
+
+      expect(selector.elements).toEqual([]);
+      expect(element.elements).toEqual([]);
+      expect(wrapper.elements).toEqual([]);
+    });
+  });
+
+  describe('display strings', () => {
+    test('selector', () => {
+      let single = createQuery('.single', document);
+      let multiple = createQuery('.multiple', document);
+      let none = createQuery('.none', document);
+
+      expect(single.description).toEqual('.single');
+      expect(multiple.description).toEqual('.multiple');
+      expect(none.description).toEqual('.none');
+
+      expect(single.selectedBy).toEqual('selected by .single');
+      expect(multiple.selectedBy).toEqual('selected by .multiple');
+      expect(none.selectedBy).toEqual('selected by .none');
+    });
+
+    test('element', () => {
+      let single = createQuery(document.querySelector('.single'), document);
+      let none = createQuery(document.querySelector('.none'), document);
+
+      expect(single.description).toEqual('div.single');
+      expect(none.description).toEqual('<not found>');
+
+      expect(single.selectedBy).toEqual('passed');
+      expect(none.selectedBy).toEqual('passed');
+    });
+
+    test('wrapped', () => {
+      let single = createQuery({ elements: [document.querySelector('.single')] }, document);
+      let multiple = createQuery({ elements: [document.querySelector('.multiple')] }, document);
+      let none = createQuery({ elements: [document.querySelector('.none')] }, document);
+
+      expect(single.description).toEqual('div.single');
+      expect(multiple.description).toEqual('div.multiple');
+      expect(none.description).toEqual('<not found>');
+
+      expect(single.selectedBy).toEqual('passed');
+      expect(multiple.selectedBy).toEqual('passed');
+      expect(none.selectedBy).toEqual('passed');
+    });
+  });
+
+  describe('root element', () => {
+    let root: Element;
+    let inRoot: Element;
+    let outOfRoot: Element;
+
+    beforeEach(() => {
+      document.body.innerHTML =
+        '<div class="root"><div class="multiple"></div></div><div class="multiple">';
+      root = document.querySelector('.root');
+      [inRoot, outOfRoot] = Array.from(document.querySelectorAll('.multiple'));
+    });
+
+    test('selector query respects root', () => {
+      expect(createQuery('.multiple', root).elements).toEqual([inRoot]);
+    });
+
+    test('element query ignores root', () => {
+      expect(createQuery(outOfRoot, root).elements).toEqual([outOfRoot]);
+    });
+
+    test('wrapped query ignores root', () => {
+      expect(createQuery({ elements: [inRoot, outOfRoot] }, root).elements).toEqual([
+        inRoot,
+        outOfRoot,
+      ]);
+    });
+  });
+
+  describe('wrapped query', () => {
+    test('elements can be a NodeList', () => {
+      let wrapped = createQuery(
+        {
+          elements: document.querySelectorAll('.multiple'),
+        },
+        document
+      );
+
+      expect(wrapped.elements).toEqual(Array.from(document.querySelectorAll('.multiple')));
+    });
+
+    test('it can explicitly define element (performance optimization)', () => {
+      let wrapped = createQuery(
+        {
+          element: document.querySelector('.single'),
+          elements: Array.from(document.querySelectorAll('.multiple')),
+        },
+        document
+      );
+
+      expect(wrapped.element).toEqual(document.querySelector('.single'));
+      expect(wrapped.elements).toEqual(Array.from(document.querySelectorAll('.multiple')));
+    });
+
+    test('it can define elementsDescription', () => {
+      let wrapped = createQuery(
+        {
+          elements: Array.from(document.querySelectorAll('.multiple')),
+          elementsDescription: 'all the elements',
+        },
+        document
+      );
+
+      expect(wrapped.description).toEqual('all the elements');
+      expect(wrapped.selectedBy).toEqual('selected by all the elements');
+    });
+
+    test('it works via assert.dom()', () => {
+      let assert = new TestAssertions();
+
+      assert.dom({ elements: document.querySelectorAll('.single') }).exists({ count: 1 });
+      assert.dom({ elements: document.querySelectorAll('.multiple') }).exists({ count: 2 });
+      assert.dom({ elements: document.querySelectorAll('.single') }).hasTagName('div');
+    });
+  });
+
+  test('throws for unexpected parameter types', () => {
+    //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
+    expect(() => createQuery(5, document).toThrow('Unexpected Parameter: 5'));
+    //@ts-ignore
+    expect(() => createQuery(true, document)).toThrow('Unexpected Parameter: true');
+    expect(() => createQuery(undefined, document)).toThrow('Unexpected Parameter: undefined');
+    //@ts-ignore
+    expect(() => createQuery({}, document)).toThrow('Unexpected Parameter: [object Object]');
+    //@ts-ignore
+    expect(() => createQuery({ element: document.createElement('div') }, document)).toThrow(
+      'Unexpected Parameter: [object Object]'
+    );
+    //@ts-ignore
+    expect(() => createQuery(document, document)).toThrow(
+      'Unexpected Parameter: [object Document]'
+    );
+  });
+});

--- a/lib/assertions/focused.ts
+++ b/lib/assertions/focused.ts
@@ -6,7 +6,7 @@ export default function focused(message?: string) {
 
   let result = document.activeElement === element;
   let actual = elementToString(document.activeElement);
-  let expected = elementToString(this.target);
+  let expected = this.targetDescription;
 
   if (!message) {
     message = `Element ${expected} is focused`;

--- a/lib/assertions/is-checked.ts
+++ b/lib/assertions/is-checked.ts
@@ -1,5 +1,3 @@
-import elementToString from '../helpers/element-to-string';
-
 export default function checked(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
@@ -21,7 +19,7 @@ export default function checked(message?: string) {
   let expected = 'checked';
 
   if (!message) {
-    message = `Element ${elementToString(this.target)} is checked`;
+    message = `Element ${this.targetDescription} is checked`;
   }
 
   this.pushResult({ result, actual, expected, message });

--- a/lib/assertions/is-not-checked.ts
+++ b/lib/assertions/is-not-checked.ts
@@ -1,5 +1,3 @@
-import elementToString from '../helpers/element-to-string';
-
 export default function notChecked(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
@@ -21,7 +19,7 @@ export default function notChecked(message?: string) {
   let expected = 'not checked';
 
   if (!message) {
-    message = `Element ${elementToString(this.target)} is not checked`;
+    message = `Element ${this.targetDescription} is not checked`;
   }
 
   this.pushResult({ result, actual, expected, message });

--- a/lib/assertions/is-not-required.ts
+++ b/lib/assertions/is-not-required.ts
@@ -1,5 +1,3 @@
-import elementToString from '../helpers/element-to-string';
-
 export default function notRequired(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
@@ -19,7 +17,7 @@ export default function notRequired(message?: string) {
   let expected = 'not required';
 
   if (!message) {
-    message = `Element ${elementToString(this.target)} is not required`;
+    message = `Element ${this.targetDescription} is not required`;
   }
 
   this.pushResult({ result, actual, expected, message });

--- a/lib/assertions/is-required.ts
+++ b/lib/assertions/is-required.ts
@@ -1,5 +1,3 @@
-import elementToString from '../helpers/element-to-string';
-
 export default function required(message?: string) {
   let element = this.findTargetElement();
   if (!element) return;
@@ -19,7 +17,7 @@ export default function required(message?: string) {
   let expected = 'required';
 
   if (!message) {
-    message = `Element ${elementToString(this.target)} is required`;
+    message = `Element ${this.targetDescription} is required`;
   }
 
   this.pushResult({ result, actual, expected, message });

--- a/lib/assertions/is-valid.ts
+++ b/lib/assertions/is-valid.ts
@@ -1,5 +1,3 @@
-import elementToString from '../helpers/element-to-string';
-
 export default function isValid(message?: string, options: { inverted?: boolean } = {}) {
   let element = this.findTargetElement();
   if (!element) return;
@@ -23,7 +21,7 @@ export default function isValid(message?: string, options: { inverted?: boolean 
   let expected = options.inverted ? 'not valid' : 'valid';
 
   if (!message) {
-    message = `Element ${elementToString(this.target)} is ${actual}`;
+    message = `Element ${this.targetDescription} is ${actual}`;
   }
 
   this.pushResult({ result, actual, expected, message });

--- a/lib/helpers/test-assertions.ts
+++ b/lib/helpers/test-assertions.ts
@@ -1,9 +1,10 @@
 import DOMAssertions, { AssertionResult } from '../assertions';
+import type { ExternalQuery } from '../query';
 
 export default class TestAssertions {
   public results: AssertionResult[] = [];
 
-  dom(target: string | Element | null, rootElement?: Element) {
+  dom(target: string | Element | null | ExternalQuery, rootElement?: Element) {
     return new DOMAssertions(target, rootElement || document, this as any);
   }
 

--- a/lib/install.ts
+++ b/lib/install.ts
@@ -1,8 +1,12 @@
 import DOMAssertions from './assertions';
+import type { ExternalQuery } from './query';
 import { getRootElement } from './root-element';
 
 export default function (assert: Assert) {
-  assert.dom = function (target?: string | Element | null, rootElement?: Element): DOMAssertions {
+  assert.dom = function (
+    target?: string | Element | null | ExternalQuery,
+    rootElement?: Element
+  ): DOMAssertions {
     if (!isValidRootElement(rootElement)) {
       throw new Error(`${rootElement} is not a valid root element`);
     }

--- a/lib/query.ts
+++ b/lib/query.ts
@@ -1,0 +1,201 @@
+import elementToString from './helpers/element-to-string';
+import { toArray } from './helpers/node-list';
+
+/**
+ * An interface for external query implementations, allowing `qunit-dom` to run
+ * assertions on objects wrapping DOM elements/queries such as page object
+ * implementations.
+ *
+ * At a minimum, implementations must provide the `elements` property, and
+ * `qunit-dom` can fill in the other functionality with reasonable
+ * assumptions/defaults.
+ *
+ * Example:
+ *
+ * ```javascript
+ * function withText(selector, text) {
+ *   let els = Array.from(document.querySelectorAll(selector));
+ *   return {
+ *     elements: els.filter(e => e.textContent.includes('submit')),
+ *     elementsDescription: `${selector}:contains(${text})`
+ *   };
+ * }
+ *
+ * assert.dom(withText('button', 'save')).exists();
+ * ```
+ */
+export interface ExternalQuery {
+  /**
+   * The DOM elements matched when executing this query as a multiple-element
+   * query, analagous to `querySelectorAll()`
+   */
+  elements: NodeListOf<Element> | Element[];
+  /**
+   * The DOM element (or null) matched when executing this query as a
+   * single-element query, analagous to `querySelector()`. If not supplied, the
+   * value will default to `elements[0]`. This property can be implemented to
+   * achieve better performance since almost all of `qunit-dom`'s assertions run
+   * single-element queries.
+   */
+  element?: Element | null;
+  /**
+   * A string describing the matched elements, e.g. the selector used to query
+   * them. If not supplied, then `qunit-dom` will generate a description by
+   * inspecting the first matching element and reading various properties and
+   * attributes off of it.
+   */
+  elementsDescription?: string;
+}
+
+/**
+ * An internal interface for querying the DOM for a single element or a list of
+ * elements (abstracts out the various types of arguments that can be passed to
+ * DOMAssertions' constructor)
+ *
+ * @private
+ */
+export interface DOMQuery {
+  /**
+   * The DOM elements matched when executing this query as a multiple-element
+   * query, analagous to `querySelectorAll()`
+   */
+  elements: Element[];
+  /**
+   * The DOM element (or null) matched when executing this query as a
+   * single-element query, analagous to `querySelector()`
+   */
+  element: Element | null;
+  /**
+   * A string describing the matched elements, e.g. the selector used to query
+   * them
+   */
+  description: string;
+  /**
+   * A prose string describing how these elements were selected, e.g. `selected
+   * by <selector>`
+   */
+  selectedBy: string;
+}
+
+/**
+ * A selector-based query, made using a root element and selector string
+ *
+ * @private
+ */
+class SelectorQuery implements DOMQuery {
+  constructor(public selector: string, private rootElement: Element | Document) {}
+
+  get element() {
+    return this.rootElement.querySelector(this.selector);
+  }
+
+  get elements() {
+    return toArray(this.rootElement.querySelectorAll(this.selector));
+  }
+
+  get description() {
+    return elementToString(this.selector);
+  }
+
+  get selectedBy() {
+    return `selected by ${this.selector}`;
+  }
+}
+
+/**
+ * A query wrapping a single element
+ *
+ * @private
+ */
+class ElementQuery implements DOMQuery {
+  constructor(public element: Element | null) {}
+
+  get elements() {
+    return this.element ? [this.element] : [];
+  }
+
+  get description() {
+    return elementToString(this.element);
+  }
+
+  selectedBy = 'passed';
+}
+
+/**
+ * A query wrapping an ExternalQuery
+ *
+ * @private
+ */
+class WrappedQuery implements DOMQuery {
+  constructor(private wrapped: ExternalQuery) {}
+
+  get element() {
+    if (Reflect.has(this.wrapped, 'element')) {
+      return Reflect.get(this.wrapped, 'element') || null;
+    } else {
+      return this.elements[0] || null;
+    }
+  }
+
+  get elements() {
+    let elements = this.wrapped.elements;
+    if (elements instanceof NodeList) {
+      return toArray(elements);
+    } else {
+      return elements;
+    }
+  }
+
+  get description() {
+    if (Reflect.has(this.wrapped, 'elementsDescription')) {
+      return Reflect.get(this.wrapped, 'elementsDescription');
+    } else {
+      return elementToString(this.element);
+    }
+  }
+
+  get selectedBy() {
+    if (Reflect.has(this.wrapped, 'elementsDescription')) {
+      return `selected by ${Reflect.get(this.wrapped, 'elementsDescription')}`;
+    } else {
+      return 'passed';
+    }
+  }
+}
+
+/**
+ * Helper to determine if an argument looks like an ExternalQuery, i.e. has an
+ * `elements` property. This exists for safe detection for Javascript users that
+ * don't have type checking.
+ *
+ * @private
+ */
+function isExternalQuery(arg: any) {
+  try {
+    return Reflect.has(arg, 'elements');
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Create a DOMQuery from various types of arguments
+ *
+ * @private
+ */
+export function createQuery(
+  target: string | Element | null | ExternalQuery,
+  rootElement: Element | Document
+): DOMQuery {
+  if (target === null) {
+    return new ElementQuery(null);
+  } else if (typeof target === 'string') {
+    return new SelectorQuery(target, rootElement);
+  } else if (target instanceof Element) {
+    return new ElementQuery(target);
+  } else if (isExternalQuery(target)) {
+    return new WrappedQuery(target);
+  } else {
+    throw new TypeError(`Unexpected Parameter: ${target}`);
+  }
+}

--- a/lib/qunit-dom.ts
+++ b/lib/qunit-dom.ts
@@ -1,13 +1,14 @@
 /* global QUnit */
 
 import type DOMAssertions from './assertions';
+import type { ExternalQuery } from './query';
 import install from './install';
 
 export { setup } from './qunit-dom-modules';
 
 declare global {
   interface Assert {
-    dom(target?: string | Element | null, rootElement?: Element): DOMAssertions;
+    dom(target?: string | Element | null | ExternalQuery, rootElement?: Element): DOMAssertions;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "rollup -c",
     "changelog": "lerna-changelog",
-    "docs": "yarn build && documentation build dist/qunit-dom.js --config documentation.yml -f md -o API.md",
+    "docs": "yarn build && documentation build dist/qunit-dom.js --config documentation.yml --infer-private '(SelectorQuery|ElementQuery|WrappedQuery)' -f md -o API.md",
     "lint": "eslint . --cache",
     "prepublish": "rollup -c",
     "release": "release-it",


### PR DESCRIPTION
Extend `qunit.dom()` to accept an object with an `elements` property so external objects that have their own DOM querying implementation like page objects can be plugged into `qunit-dom`'s assertion API.

This is based on a Discord discussion with @Turbo87, and is aimed at supporting my new and still very much WIP page object library (see [the tests](https://github.com/bendemboski/lazy-page-object/blob/main/packages/ember-app/tests/integration/page-object-test.ts) for a rough idea of the usage patterns), and also at supporting any number of extensions to `qunit-dom`'s querying functionality like #864. 

Some notes:

#### Why `elementsDescription`?

I chose the name `elementsDescription` rather than the more terse `description` to support page object implementations where the page object nodes are passed directly into `qunit-dom`. In this case, any properties read by `qunit-dom` need to be reserved for "internal use" by the page object implementation, disallowing users from using those names for child nodes. This seems reasonable for `elements` and `element`, but much less so for `description`. For example, using `ember-cli-page-object`'s API (imagining that it were extended to plug into `qunit-dom`):

```javascript
import PageObject from 'ember-cli-page-object';

const page = PageObject.create({
  imageTiles: {
    scope: '[data-test-image-tile]',
    image: { scope: 'img' },
    description: { scope: '[data-test-description]' }
  }
});

// fine
assert.dom(page.imageTiles.objectAt(0).image).hasAttribute('src', 'funnyCatPic.jpg');
// whoops, description is a reserved property name that `qunit-dom` expects to contain a string!
// So either `assert.dom(page.imageTiles.objectAt(0))` would get a description of `[object Object]`
// or `assert.dom(page.imageTiles.objectAt(0).description)` would get a description string passed
// to it instead of a page object
assert.dom(page.imageTiles.objectAt(0)).exists();
assert.dom(page.imageTiles.objectAt(0).description).hasText('haha, a funny cat picture, how original');
```

I'm definitely open to other ideas for how to expose this information to `qunit-dom` in a way that isn't overly likely to cause page object footguns.

#### `<unknown>` vs. `<not found>`

`<unknown>` was [used](https://github.com/simplabs/qunit-dom/blob/d559dad1eff8467125c606aec51c9bda3f591089/lib/assertions.ts#L1355) for the assertion message when `null` was passed in as the `target`, but if a selector was passed in that didn't match anything, the selector string would be used. In the other assertion messages where the element was not found, `<not found>` was [used](https://github.com/simplabs/qunit-dom/blob/d559dad1eff8467125c606aec51c9bda3f591089/lib/helpers/element-to-string.ts#L4). I couldn't figure out what value this distinction was providing (if any, maybe just an accident of how the code evolved?), so I couldn't figure out how to translate it to the `DOMQuery` abstraction, so I just eliminated it, meaning some of the assertion strings have changed (as you can see from the tests). If there's a reason to keep `<unknown>` I'm happy to discuss how to revive it.

#### documentation

As mentioned in the second commit, updating the documentation was a bit of a PITA mainly, I think, because of some limitations of `documentation`. I did try switching to generating the documentation off of the typescript so we don't have to hard-code the `ExternalQuery` documentation in `documentation.yml`, but then it generated a separate entry for each typescript function overload signature, which seemed less than helpful. Anyway, this is the best I could come up with but am happy to entertain other ideas.