### PR TITLE
Clarified how to update tests/test-helper.js when migrating ember-qunit to v5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,21 @@ Import and run the `setup` function in your `test-helper.js` file:
 
 ```js
 // tests/test-helper.js
+import * as QUnit from 'qunit';
 import { setup } from 'qunit-dom';
 
 //...
 
 setup(QUnit.assert);
 
+setApplication(Application.create(config.APP));
+
+start();
+
 //...
 ```
 
-this will attach the APIs to QUnit's `assert` object.
+This will attach the APIs to QUnit's `assert` object.
 
 ### Ember projects using `ember-qunit` v4.x and below
 


### PR DESCRIPTION
## Description

Currently, the `README` shows the following code snippet to help with upgrading `ember-qunit` to `v5.x` or above:

```javascript
// tests/test-helper.js
import { setup } from 'qunit-dom';

//...

setup(QUnit.assert);

//...
```

I encountered the following error because I didn't import `QUnit`:

```bash
Global error: Uncaught ReferenceError: QUnit is not defined at http://localhost:7357/assets/tests.js
```

In this pull request, I updated the code snippet to show a developer (1) how they are to import `QUnit` and `setup`, and (2) in what recommended order they can call `setup`. I used QUnit DOM's own [test helper](https://github.com/simplabs/qunit-dom/blob/18e6ea1d6b6be7fe244bc5da002802f5fd6376a9/tests/test-helper.js) to decide the recommended order.