### PR TITLE
Drop support for Node.js 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: ['10', '12', '14', '16']
+        node: ['12', '14', '16']
 
     name: Tests (Node.js v${{ matrix.node }})
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "typescript": "4.4.2"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "12.* || 14.* || >= 16.*"
   },
   "changelog": {
     "repo": "simplabs/qunit-dom",


### PR DESCRIPTION
Node.js 10 is no longer officially supported by the team (see https://nodejs.org/en/about/releases/)