### PR TITLE
CI: Fix `release` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 10
+          node-version: 14
           registry-url: 'https://registry.npmjs.org'
 
       - run: yarn install


### PR DESCRIPTION
If we drop support for Node.js 10, we shouldn't try to use it to publish the package... 🤦‍♂️