### PR TITLE
Remove duplicate `ember-cli-babel` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "documentation": "13.2.5",
     "ember-auto-import": "1.12.0",
     "ember-cli": "3.28.0",
-    "ember-cli-babel": "7.26.6",
     "ember-cli-dependency-checker": "3.2.0",
     "ember-cli-htmlbars": "5.7.1",
     "ember-cli-inject-live-reload": "2.1.0",


### PR DESCRIPTION
The duplicate got added by https://github.com/simplabs/qunit-dom/commit/4f83836260dc86c74017935be6f3e75fff1911a9 without removing the other one 😅 