### PR TITLE
Fix documentation for pseudo element style

### DIFF
--- a/API.md
+++ b/API.md
@@ -615,7 +615,7 @@ Assert that the pseudo element for `selector` of the [HTMLElement][] has the `ex
 #### Examples
 
 ```javascript
-assert.dom('.progress-bar').hasPseudoElementStyle(':after', {
+assert.dom('.progress-bar').hasPseudoElementStyle('after', {
   content: '";"',
 });
 ```
@@ -659,7 +659,7 @@ Assert that the pseudo element for `selector` of the [HTMLElement][] does not ha
 #### Examples
 
 ```javascript
-assert.dom('.progress-bar').doesNotHavePseudoElementStyle(':after', {
+assert.dom('.progress-bar').doesNotHavePseudoElementStyle('after', {
   content: '";"',
 });
 ```


### PR DESCRIPTION
When using `getComputedStyle` according to the MDN page https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle, we shouldn't pass the `:`.

Have tested this on our local setup and tests pass *without* the ':', but fail with it.