### PR TITLE
Fix `hasAria()` docs and add `hasNoAria()` and `lacksAria()` aliases

### DIFF
--- a/lib/__tests__/has-aria.ts
+++ b/lib/__tests__/has-aria.ts
@@ -15,12 +15,26 @@ describe('assert.dom(...).hasAria()', () => {
   test('smoke test', () => {
     assert.dom('button').hasAria('pressed', 'true');
     assert.dom('button').doesNotHaveAria('hidden');
+    assert.dom('button').hasNoAria('hidden');
+    assert.dom('button').lacksAria('hidden');
 
     expect(assert.results).toEqual([
       {
         actual: 'Element button has attribute "aria-pressed" with value "true"',
         expected: 'Element button has attribute "aria-pressed" with value "true"',
         message: 'Element button has attribute "aria-pressed" with value "true"',
+        result: true,
+      },
+      {
+        actual: 'Element button does not have attribute "aria-hidden"',
+        expected: 'Element button does not have attribute "aria-hidden"',
+        message: 'Element button does not have attribute "aria-hidden"',
+        result: true,
+      },
+      {
+        actual: 'Element button does not have attribute "aria-hidden"',
+        expected: 'Element button does not have attribute "aria-hidden"',
+        message: 'Element button does not have attribute "aria-hidden"',
         result: true,
       },
       {

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -445,7 +445,7 @@ export default class DOMAssertions {
    * @param {string?} message
    *
    * @example
-   * assert.dom('input.username').hasNoAttribute('disabled');
+   * assert.dom('input.username').doesNotHaveAttribute('disabled');
    *
    * @see {@link #hasAttribute}
    */

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -492,7 +492,7 @@ export default class DOMAssertions {
    * @example
    * assert.dom('button').hasAria('pressed', 'true');
    *
-   * @see {@link #hasNoAria}
+   * @see {@link #doesNotHaveAria}
    */
   hasAria(name: string, value?: string | RegExp | { any: true }, message?: string): DOMAssertions {
     return this.hasAttribute(`aria-${name}`, value, message);

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -502,6 +502,8 @@ export default class DOMAssertions {
    * Assert that the {@link HTMLElement} has no ARIA attribute with the
    * provided `name`.
    *
+   * **Aliases:** `hasNoAria`, `lacksAria`
+   *
    * @param {string} name
    * @param {string?} message
    *
@@ -512,6 +514,14 @@ export default class DOMAssertions {
    */
   doesNotHaveAria(name: string, message?: string): DOMAssertions {
     return this.doesNotHaveAttribute(`aria-${name}`, message);
+  }
+
+  hasNoAria(name: string, message?: string): DOMAssertions {
+    return this.doesNotHaveAria(name, message);
+  }
+
+  lacksAria(name: string, message?: string): DOMAssertions {
+    return this.doesNotHaveAria(name, message);
   }
 
   /**


### PR DESCRIPTION
This:
- updates the link in `hasAria()`'s doc block from `hasNoAria()` to `doesNotHaveAria()`
- adds `hasNoAria()` and `lacksAria()` as aliases for `doesNotHaveAria()` to be consistent with `hasNoAttribute()` and `lacksAttribute()` aliases for `doesNotHaveAttribute()` (and other doesNotHave assertions)
- updates the example in `doesNotHaveAttribute()` to use `doesNotHaveAttribute()` instead of its alias `hasNoAttribute()`

Note: I can't get `pnpm run docs` to succeed so this PR doesn't update `API.md`
