### PR TITLE
Remove `engines` declaration from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,6 @@
     "typescript": "4.6.4",
     "webpack": "5.72.1"
   },
-  "engines": {
-    "node": "12.* || 14.* || >= 16.*"
-  },
   "changelog": {
     "repo": "simplabs/qunit-dom",
     "labels": {


### PR DESCRIPTION
Since this is not a Node.js package, it does not make sense for us to declare what Node.js version we're compatible with, especially if it means that adjusting the value could be considered a breaking change.