### PR TITLE
tests: Remove `global` usage

### DIFF
--- a/lib/__tests__/includes-text.ts
+++ b/lib/__tests__/includes-text.ts
@@ -142,7 +142,7 @@ describe('assert.dom(...).includesText()', () => {
     });
 
     test('explains failures to the user via `console.warn` if expected text contains collapsable whitespace', () => {
-      const warnSpy = jest.spyOn(global.console, 'warn').mockImplementation(() => {});
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       assert.dom(element).includesText('foo\n  bar');
 


### PR DESCRIPTION
This is blocking #1550 for some reason 🤷‍♂️ 