### PR TITLE
chore(qunit-dom): expose private install types

### DIFF
--- a/packages/qunit-dom/lib/install.ts
+++ b/packages/qunit-dom/lib/install.ts
@@ -2,22 +2,23 @@ import DOMAssertions from './assertions.js';
 import { getRootElement } from './root-element.js';
 import type { IDOMElementDescriptor } from 'dom-element-descriptors';
 
-declare global {
-  type RootElement = Element | Document | ShadowRoot | null;
+type TRoot = Element | Document | ShadowRoot | null;
 
-  interface Assert {
-    dom(
-      target?: string | Element | IDOMElementDescriptor | null,
-      rootElement?: RootElement
-    ): DOMAssertions;
-  }
+interface IAssert {
+  dom(target?: DOMTarget, rootElement?: RootElement): DOMAssertions;
+}
+
+export type RootElement = TRoot;
+export type Assert = IAssert;
+export type DOMTarget = string | Element | IDOMElementDescriptor | null;
+
+declare global {
+  type RootElement = TRoot;
+  interface Assert extends IAssert {}
 }
 
 export default function (assert: Assert) {
-  assert.dom = function (
-    target?: string | Element | IDOMElementDescriptor | null,
-    rootElement?: RootElement
-  ): DOMAssertions {
+  assert.dom = function (target?: DOMTarget, rootElement?: RootElement): DOMAssertions {
     if (!isValidRootElement(rootElement)) {
       throw new Error(`${rootElement} is not a valid root element`);
     }

--- a/packages/qunit-dom/lib/qunit-dom.ts
+++ b/packages/qunit-dom/lib/qunit-dom.ts
@@ -2,5 +2,6 @@
 import install from './install.js';
 
 export { setup } from './qunit-dom-modules.js';
+export type { RootElement, Assert, DOMTarget } from './install.js';
 
 install(QUnit.assert);


### PR DESCRIPTION
`ember-data` found a need to import the Assert interface for it's internal Diagnostic module.
This exposes the types so it's not necessary to patch the dependency directly 

https://github.com/emberjs/data/pull/10122