### PR TITLE
Fix `assert.dom(undefined)` does not throw, fixes #2186

### DIFF
--- a/packages/qunit-dom/lib/assertions.ts
+++ b/packages/qunit-dom/lib/assertions.ts
@@ -54,7 +54,7 @@ export default class DOMAssertions {
    * @hideconstructor
    */
   constructor(
-    target: string | Element | null | IDOMElementDescriptor,
+    target: string | Element | null | IDOMElementDescriptor | undefined,
     rootElement: RootElement,
     private testContext: Assert
   ) {

--- a/packages/qunit-dom/lib/descriptor.ts
+++ b/packages/qunit-dom/lib/descriptor.ts
@@ -47,7 +47,7 @@ class ElementData {
  * Create an {@link IDOMElementDescriptor} from a target and a root element
  */
 export default function createDescriptor(
-  target: string | Element | null | IDOMElementDescriptor,
+  target: string | Element | null | IDOMElementDescriptor | undefined,
   rootElement: RootElement
 ): IDOMElementDescriptor {
   if (typeof target === 'string') {

--- a/packages/qunit-dom/lib/install.ts
+++ b/packages/qunit-dom/lib/install.ts
@@ -25,11 +25,13 @@ export default function (assert: Assert) {
 
     rootElement = rootElement || this.dom.rootElement || getRootElement();
 
-    return new DOMAssertions(
-      target !== undefined ? target : rootElement instanceof Element ? rootElement : null,
-      rootElement,
-      this
-    );
+    // Only default to rootElement when NO arguments provided.
+    // This allows assert.dom(undefined) to throw while assert.dom() still works.
+    if (arguments.length === 0) {
+      target = rootElement instanceof Element ? rootElement : null;
+    }
+
+    return new DOMAssertions(target, rootElement, this);
   };
 
   function isValidRootElement(element: any): element is Element {

--- a/packages/test-app/tests/acceptance/qunit-dom-test.js
+++ b/packages/test-app/tests/acceptance/qunit-dom-test.js
@@ -51,5 +51,11 @@ module('Acceptance | qunit-dom', function (hooks) {
       () => assert.dom('foo', 'bar'),
       /bar is not a valid root element/,
     );
+
+    assert.throws(
+      () => assert.dom(undefined),
+      /Unexpected Parameter: undefined/,
+      'assert.dom(undefined) throws',
+    );
   });
 });


### PR DESCRIPTION
When `assert.dom(undefined)` is called, it incorrectly defaults to the root element instead of throwing `TypeError: Unexpected Parameter: undefined`. This means code like `assert.dom(findAll('.foo')[0]).exists()` silently passes even when `.foo` doesn't exist (because `findAll` returns an empty array, and `array[0]` is `undefined`).

PR #2107 changed the argument detection logic from `arguments.length === 0` to `target !== undefined`, which cannot distinguish between "no argument" and passing "undefined".

This behavior was not caught by tests because tests only used mock implementation of `assert.dom`.

This commit restores the original behavior that correctly distinguishes passing no arguments and passing undefined and adds a test to ensure passing undefined throws an error as expected.

Addresses:
https://github.com/mainmatter/qunit-dom/issues/2186